### PR TITLE
Rename plan->studentPlan and planById->plan

### DIFF
--- a/gql/graphql.ts
+++ b/gql/graphql.ts
@@ -135,11 +135,11 @@ export class PlanOfStudy {
 }
 
 export abstract class IQuery {
-    abstract plan(studentID: string): Nullable<PlanOfStudy> | Promise<Nullable<PlanOfStudy>>;
+    abstract stduentPlan(studentID: string): Nullable<PlanOfStudy> | Promise<Nullable<PlanOfStudy>>;
 
     abstract plans(): Nullable<PlanOfStudy[]> | Promise<Nullable<PlanOfStudy[]>>;
 
-    abstract planByID(id: string): Nullable<PlanOfStudy> | Promise<Nullable<PlanOfStudy>>;
+    abstract plan(id: string): Nullable<PlanOfStudy> | Promise<Nullable<PlanOfStudy>>;
 
     abstract modules(): Module[] | Promise<Module[]>;
 

--- a/gql/graphql.ts
+++ b/gql/graphql.ts
@@ -135,11 +135,11 @@ export class PlanOfStudy {
 }
 
 export abstract class IQuery {
-    abstract stduentPlan(studentID: string): Nullable<PlanOfStudy> | Promise<Nullable<PlanOfStudy>>;
+    abstract plan(studentID: string): Nullable<PlanOfStudy> | Promise<Nullable<PlanOfStudy>>;
 
     abstract plans(): Nullable<PlanOfStudy[]> | Promise<Nullable<PlanOfStudy[]>>;
 
-    abstract plan(id: string): Nullable<PlanOfStudy> | Promise<Nullable<PlanOfStudy>>;
+    abstract planByID(id: string): Nullable<PlanOfStudy> | Promise<Nullable<PlanOfStudy>>;
 
     abstract modules(): Module[] | Promise<Module[]>;
 

--- a/src/pos/pos.resolver.ts
+++ b/src/pos/pos.resolver.ts
@@ -1,4 +1,4 @@
-import { Resolver, Query, Args, Mutation} from "@nestjs/graphql";
+import { Resolver, Query, Args, Mutation } from "@nestjs/graphql";
 import { Prisma } from "@prisma/client";
 import { PlanInput } from "gql/graphql";
 import { PoSService } from "./pos.service";
@@ -15,7 +15,7 @@ export class PlanOfStudyResolver {
 
 	@Query("plan")
 	async plan(@Args("studentID") studentID: string) {
-		return this.planService.planById(studentID);
+		return this.planService.studentPlan(studentID);
 	}
 
 	@Query("planByID")

--- a/src/pos/pos.service.ts
+++ b/src/pos/pos.service.ts
@@ -31,7 +31,7 @@ export class PoSService {
 
 	// Find a plan based on it's document ID
 	async plan(id: string): Promise<PlanOfStudy | null> {
-		const res = await this.prisma.planOfStudy.findUnique({
+		return await this.prisma.planOfStudy.findUnique({
 			where: {
 				id
 			},
@@ -56,20 +56,29 @@ export class PoSService {
 				student: true
 			}
 		});
-		return res;
 	}
 
-	// TODO: figure out why this is not working
 	// Find a plan based on the student's ID associated with the document
 	async studentPlan(studentID: string): Promise<PlanOfStudy | null> {
-		const res = await this.prisma.planOfStudy.findFirst({
+		return await this.prisma.planOfStudy.findFirst({
 			where: {
 				studentID
 			},
 			include: {
 				modules: {
 					include: {
-						module: true,
+						module: {
+							include: {
+								feedback: true,
+								assignments: true,
+								members: true,
+								parentCourses: {
+									include: {
+										course: true
+									}
+								}
+							}
+						},
 						plan: true
 					}
 				},
@@ -87,8 +96,6 @@ export class PoSService {
 				student: true
 			}
 		});
-
-		return res;
 	}
 
 	// TODO: Allow for starting modules and courses

--- a/src/pos/pos.service.ts
+++ b/src/pos/pos.service.ts
@@ -30,7 +30,7 @@ export class PoSService {
 	}
 
 	// Find a plan based on it's document ID
-	async planById(id: string): Promise<PlanOfStudy | null> {
+	async plan(id: string): Promise<PlanOfStudy | null> {
 		const res = await this.prisma.planOfStudy.findUnique({
 			where: {
 				id
@@ -61,7 +61,7 @@ export class PoSService {
 
 	// TODO: figure out why this is not working
 	// Find a plan based on the student's ID associated with the document
-	async plan(studentID: string): Promise<PlanOfStudy | null> {
+	async studentPlan(studentID: string): Promise<PlanOfStudy | null> {
 		const res = await this.prisma.planOfStudy.findFirst({
 			where: {
 				studentID

--- a/src/pos/schema.graphql
+++ b/src/pos/schema.graphql
@@ -13,9 +13,9 @@ input PlanInput {
 
 
 type Query {
-	plan(studentID: ID!): PlanOfStudy
+	stduentPlan(studentID: ID!): PlanOfStudy
 	plans: [PlanOfStudy!]
-	planByID(id: String!): PlanOfStudy
+	plan(id: String!): PlanOfStudy
 }
 
 type Mutation {

--- a/src/pos/schema.graphql
+++ b/src/pos/schema.graphql
@@ -11,11 +11,10 @@ input PlanInput {
 	student: ID
 }
 
-
 type Query {
-	stduentPlan(studentID: ID!): PlanOfStudy
+	plan(studentID: ID!): PlanOfStudy
 	plans: [PlanOfStudy!]
-	plan(id: String!): PlanOfStudy
+	planByID(id: String!): PlanOfStudy
 }
 
 type Mutation {


### PR DESCRIPTION
Just renamed the two queries to try and eliminate some confusion
plan has become studentPlan (_For getting a plan based on student ID_)
planById has become plan (_For getting a plan based on the plan's ID_)