### PR TITLE
fix(user): :bug: Instructor profiles can now be upadted and also fetched through user/users/updateUser queries/mutations

### DIFF
--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -34,7 +34,8 @@ export class UserService {
 						}
 					}
 				},
-				assignmentGraded: true
+				assignmentGraded: true,
+				instructorProfile: true
 			}
 		});
 	}
@@ -56,7 +57,8 @@ export class UserService {
 						}
 					}
 				},
-				assignmentGraded: true
+				assignmentGraded: true,
+				instructorProfile: true
 			}
 		});
 
@@ -150,7 +152,6 @@ export class UserService {
 	}
 
 	// Update a user
-	// TODO: figure out why the UserUpdateInput does not contain the id field
 	async updateUser(params: UpdateUser): Promise<User | Error> {
 		try {
 			const {
@@ -163,8 +164,8 @@ export class UserService {
 				passwordConf,
 				dob,
 				isAdmin,
-				isActive
-				// instructorProfile
+				isActive,
+				instructorProfile
 			} = params;
 
 			//check if passwords provided match
@@ -190,24 +191,21 @@ export class UserService {
 			const hashedPassword = await hash(password, 10);
 			const hashedPasswordConf = hashedPassword;
 
-			// console.log(`Here is the instructor profile ${instructorProfile}`);
-
-			// if (instructorProfile !== undefined) {
-			// 	try {
-			// 		await this.prisma.instructorProfile.update({
-			// 			where: {
-			// 				accountID: id
-			// 			},
-			// 			// @ts-ignore
-			// 			data: {
-			// 				...(instructorProfile && { instructorProfile })
-			// 			}
-			// 		});
-			// 	} catch (error) {
-			// 		//@ts-ignore
-			// 		throw new Error(error.message);
-			// 	}
-			// }
+			if (instructorProfile !== null || instructorProfile !== undefined) {
+				try {
+					await this.prisma.instructorProfile.update({
+						where: {
+							accountID: id
+						},
+						data: {
+							...instructorProfile
+						}
+					});
+				} catch (error) {
+					//@ts-ignore
+					throw new Error(error.message);
+				}
+			}
 
 			if (!moment(dob).isValid()) {
 				throw new Error("Invalid date of birth");
@@ -229,6 +227,9 @@ export class UserService {
 					...(passwordConf && { passwordConf: hashedPasswordConf }),
 					...(isAdmin && { isAdmin }),
 					...(isActive && { isActive })
+				},
+				include: {
+					instructorProfile: true
 				}
 			});
 		} catch (error) {


### PR DESCRIPTION
I added the include propery for user and users queries so instructor profile objects get populated on fetch. Also uncommented the instructor profile propery in the updateUser mutation which also handles errors on a primitive level

Closes ALMP-224 from API side
