### PR TITLE
Add login error handling and cookie storage on login

### DIFF
--- a/src/auth/auth.resolver.ts
+++ b/src/auth/auth.resolver.ts
@@ -7,12 +7,15 @@ import { AuthService } from './auth.service';
 export class AuthResolver {
 
     constructor(private readonly authService: AuthService) {}
-
     @Query("login")
     //@UseGuards(AuthGuard('google'))
     async login(@Context() context: GraphQLExecutionContext, @Args("code") code: String) {
         // Init the users login flow
         const response = await this.authService.fetchToken(code)
+        if (!response.ok) {
+            throw new Error("Error " + response.status + ": " + response.statusText);
+            
+        }
         const data = await response.json();
         //@ts-ignore
         context.res.cookie('test', 'value');

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -7,11 +7,12 @@ export class AuthService {
     async fetchToken(code: String) {
         const response = await fetch("https://oauth2.googleapis.com/token", {
             method: 'POST',
+            credentials: 'include',
             body: JSON.stringify({
                 client_id: process.env.GOOGLE_ID,
                 client_secret: process.env.GOOGLE_SECRET,
                 grant_type: 'authorization_code',
-                redirect_uri: 'http://localhost:3000/redirect',
+                redirect_uri: 'http://localhost:3000/api/auth/redirect',
                 code
             })
         });


### PR DESCRIPTION
The cookie stores now, but the error handling is questionable. Google always returns a 400 status any time the request fails. I'm not sure if this is correct or not but the status and its message are thrown in the `auth.resolver`.