### PR TITLE
:sparkles: (user): Optimized user queries to use the same service

### DIFF
--- a/gql/graphql.ts
+++ b/gql/graphql.ts
@@ -362,9 +362,7 @@ export interface IQuery {
     collection(id: string): Nullable<Collection> | Promise<Nullable<Collection>>;
     lessons(input?: Nullable<LessonFields>): Nullable<Lesson[]> | Promise<Nullable<Lesson[]>>;
     content(input?: Nullable<ContentFields>): Nullable<Content[]> | Promise<Nullable<Content[]>>;
-    user(id: string): Nullable<User> | Promise<Nullable<User>>;
-    users(): User[] | Promise<User[]>;
-    usersByParam(input?: Nullable<UserFields>): Nullable<User[]> | Promise<Nullable<User[]>>;
+    user(input?: Nullable<UserFields>): User[] | Promise<User[]>;
     socials(): Social[] | Promise<Social[]>;
     social(id: string): Nullable<Social> | Promise<Nullable<Social>>;
     socialsByParam(input?: Nullable<SocialFields>): Nullable<Social[]> | Promise<Nullable<Social[]>>;

--- a/prisma/dbml/schema.dbml
+++ b/prisma/dbml/schema.dbml
@@ -5,7 +5,7 @@
 Table User {
   id String [pk]
   openID String [unique, not null]
-  email String [unique, not null]
+  email String [not null]
   picURL String
   createdAt DateTime [default: `now()`, not null]
   firstName String [not null]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,7 @@ generator dbml {
 model User {
   id         String    @id @default(auto()) @map("_id") @db.ObjectId
   openID     String    @unique
-  email      String    @unique
+  email      String
   picURL     String?
   createdAt  DateTime  @default(now())
   firstName  String

--- a/src/community/community.spec.ts
+++ b/src/community/community.spec.ts
@@ -4,6 +4,8 @@ import { IThreadCreateInput } from "@/types/graphql";
 import { AuthService } from "@/auth/auth.service";
 import { UserService } from "@/user/user.service";
 import { PlanOfStudyResolver, PoSService } from "@/pos";
+import { pickRandomFromArray, shuffle } from "../../utils/tests";
+import { Thread } from "@prisma/client";
 
 describe("Community", () => {
 	let service: CommunityService;
@@ -18,18 +20,12 @@ describe("Community", () => {
 	let accountID: string;
 	let threadID: string;
 
-	const pickRandomFromArray = (arr: any[]): number => {
-		return Math.floor(Math.random() * arr.length);
-	};
-
-	const shuffle = (str) => [...str].sort(() => Math.random() - 0.5).join("");
-
 	const createThread = async (input: IThreadCreateInput) => {
 		return await resolver.createThread(input);
 	};
 
 	const deleteThread = async (id: string) => {
-		return await resolver.deleteThread(id);
+		return (await resolver.deleteThread(id)) as Thread;
 	};
 
 	const deleteUser = async (id: string) => {

--- a/src/user/schema.graphql
+++ b/src/user/schema.graphql
@@ -4,7 +4,7 @@ type Social {
 	"""
 	id: ID!
 	"""
-	Url Poiting to Twitter
+	Url Pointing to Twitter
 	"""
 	twitter: String
 	"""
@@ -20,7 +20,7 @@ type Social {
 	"""
 	facebook: String
 	"""
-	Url poiting to porfolio
+	Url pointing to portfolio
 	"""
 	portfolio: String
 	"""
@@ -31,7 +31,7 @@ type Social {
 
 type InstructorProfile {
 	"""
-	Intrucutor Profile id
+	Instructor Profile id
 	"""
 	id: ID!
 	"""
@@ -39,7 +39,7 @@ type InstructorProfile {
 	"""
 	account: User
 	"""
-	Title of the IntructorProfile
+	Title of the Instructor Profile
 	"""
 	title: String
 	"""
@@ -63,7 +63,7 @@ type InstructorProfile {
 	"""
 	background: String
 	"""
-	Researchinterest of the User
+	Research interest of the User
 	"""
 	researchInterest: String
 	"""
@@ -71,11 +71,11 @@ type InstructorProfile {
 	"""
 	selectedPapersAndPublications: String
 	"""
-	Personal webiste of the user
+	Personal website of the user
 	"""
 	personalWebsite: String
 	"""
-	Philosopy
+	The preferred teaching philosophy of the instructor
 	"""
 	philosophy: String
 }
@@ -110,7 +110,7 @@ type User {
 	"""
 	lastName: String
 	"""
-	Middlename of the user
+	Middle name of the user
 	"""
 	middleName: String
 	"""
@@ -130,7 +130,7 @@ type User {
 	"""
 	social: Social
 	"""
-	User planofstudy
+	User plan of study
 	"""
 	plan: PlanOfStudy
 	"""
@@ -138,11 +138,11 @@ type User {
 	"""
 	tokens: [ID!]
 	"""
-	feedback of the user pointing to modulefeedback
+	feedback of the user pointing to module feedback
 	"""
 	feedback: [ModuleFeedback!]
 	"""
-	assignment graded poiting to assignment result of the user
+	assignment graded pointing to assignment result of the user
 	"""
 	assignmentGraded: [AssignmentResult!]
 	"""
@@ -192,7 +192,7 @@ input NewUser {
 	"""
 	email: String!
 	"""
-	picUrl of the Newuser
+	picUrl of the New user
 	"""
 	picURL: String!
 	"""
@@ -253,7 +253,7 @@ input UpdateUser {
 	"""
 	email: String
 	"""
-	Picurl of update user
+	Picture URL of update user
 	"""
 	picURL: String
 	"""
@@ -288,15 +288,15 @@ input UpdateUser {
 
 input InstructorProfileInput {
 	"""
-	Intructor profile title
+	Instructor profile title
 	"""
 	title: String
 	"""
-	Officelocation of Instructor Profile
+	Office-location of Instructor Profile
 	"""
 	officeLocation: String
 	"""
-	Offcie hours of Instructor Profile
+	Office hours of Instructor Profile
 	"""
 	officeHours: String
 	"""
@@ -304,11 +304,11 @@ input InstructorProfileInput {
 	"""
 	contactPolicy: String
 	"""
-	Phone of Intructor Profile
+	Phone of Instructor Profile
 	"""
 	phone: String
 	"""
-	Backgroud of Profile
+	Background of Profile
 	"""
 	background: String
 	"""
@@ -324,14 +324,14 @@ input InstructorProfileInput {
 	"""
 	personalWebsite: String
 	"""
-	Philisophy of the Instructor
+	Philosophy of the Instructor
 	"""
 	philosophy: String
 }
 
 input SocialInput {
 	"""
-	Url poiting to Twitter
+	Url pointing to Twitter
 	"""
 	twitter: String
 	"""
@@ -343,26 +343,20 @@ input SocialInput {
 	"""
 	linkedin: String
 	"""
-	Url poiting to facebook
+	Url pointing to facebook
 	"""
 	facebook: String
 	"""
-	Url poiting to portfolio
+	Url pointing to portfolio
 	"""
 	portfolio: String
 }
 
 type Query {
 	"""
-	Query that fetches User on id
+	Query that fetches User based on the passed in parameters. If openID or id fields are set in the input, the returned user is guaranteed to be unique. If no params are provided, all users are returned
 	"""
-	user(id: ID!): User
-	"""
-	Query that fetches all the users
-	"""
-	users: [User!]!
-
-	usersByParam(input: UserFields): [User!]
+	user(input: UserFields): [User!]!
 	"""
 	Query that fetches all the socials
 	"""
@@ -374,7 +368,7 @@ type Query {
 
 	socialsByParam(input: SocialFields): [Social!]
 	"""
-	Query that fetches instrctor Profile based on id
+	Query that fetches instructor Profile based on id
 	"""
 	instructorProfile(id: ID!): InstructorProfile
 }
@@ -410,7 +404,7 @@ type Mutation {
 	"""
 	deleteSocial(id: ID!): Social
 	"""
-	Delets User social
+	Deletes User social
 	"""
 	deleteUserSocial(userId: ID!): Social
 }

--- a/src/user/user.resolver.ts
+++ b/src/user/user.resolver.ts
@@ -1,6 +1,5 @@
 import { Resolver, Query, Args, Mutation } from "@nestjs/graphql";
 import {
-	NewUser,
 	UpdateUser,
 	SocialInput,
 	UserFields,
@@ -41,8 +40,7 @@ export class UserResolver {
 	async instructorProfile(@Args("id") id: string) {
 		const usr = await this.user({ id });
 		if (usr instanceof Error) return new Error("User not found");
-		//@ts-ignore
-		else return await this.userService.instructorProfile(usr.id);
+		else return await this.userService.instructorProfile(usr[0].id);
 	}
 
 	@Mutation("updateUser")

--- a/src/user/user.resolver.ts
+++ b/src/user/user.resolver.ts
@@ -1,10 +1,12 @@
+import { Resolver, Query, Args, Mutation } from "@nestjs/graphql";
 import {
-	Resolver,
-	Query,
-	Args,
-	Mutation,
-} from "@nestjs/graphql";
-import { NewUser, UpdateUser, SocialInput, UserFields, SocialFields } from "gql/graphql";
+	NewUser,
+	UpdateUser,
+	SocialInput,
+	UserFields,
+	SocialFields,
+	User
+} from "gql/graphql";
 import { UserService } from "./user.service";
 
 @Resolver("User")
@@ -12,21 +14,12 @@ import { UserService } from "./user.service";
 export class UserResolver {
 	constructor(private readonly userService: UserService) {}
 
-	// Get all users
-	@Query("users")
-	async users() {
-		return await this.userService.users();
-	}
-
-	// Get a single user
+	// Get users by params in input
 	@Query("user")
-	async user(@Args("id") args: string) {
-		return await this.userService.user(args);
-	}
-
-	@Query("usersByParam")
-	async usersByParam(@Args("input") params: UserFields) {
-		return await this.userService.usersByParam(params);
+	async user(@Args("input") params: UserFields) {
+		const account = await this.userService.usersByParam(params);
+		if (!account) return new Error("User not found");
+		return account;
 	}
 
 	@Query("socials")
@@ -46,15 +39,10 @@ export class UserResolver {
 
 	@Query("instructorProfile")
 	async instructorProfile(@Args("id") id: string) {
-		const usr = await this.userService.user(id);
-		if(usr) return await this.userService.instructorProfile(usr.id);
-		else throw new Error("User not found");
-	}
-
-	@Mutation("createUser")
-	async createUser(@Args("input") args: NewUser) {
-		// return await this.userService.registerUser(args);
-		return
+		const usr = await this.user({ id });
+		if (usr instanceof Error) return new Error("User not found");
+		//@ts-ignore
+		else return await this.userService.instructorProfile(usr.id);
 	}
 
 	@Mutation("updateUser")

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@nestjs/common";
-import { PrismaService } from "../prisma.service";
+import { PrismaService } from "@/prisma.service";
 import type { User, Social } from "@prisma/client";
 import type {
 	UpdateUser,
@@ -10,56 +10,19 @@ import type {
 	SocialFields
 } from "gql/graphql";
 import moment from "moment";
+import { Prisma } from "@prisma/client";
 
 @Injectable()
 export class UserService {
-	constructor(private prisma: PrismaService) {}
-
-	// Get all users
-	async users(): Promise<User[]> {
-		return this.prisma.user.findMany({
-			include: {
-				feedback: true,
-				plan: {
-					include: {
-						modules: {
-							include: {
-								module: true
-							}
-						}
-					}
-				},
-				assignmentGraded: true,
-				instructorProfile: true
-			}
-		});
+	constructor(private prisma: PrismaService) {
+		this.prisma = prisma;
 	}
 
-	// Get a single user based on ID
-	async user(id: string): Promise<User | null> {
-		return this.prisma.user.findFirst({
-			where: {
-				openID: id
-			},
-			include: {
-				feedback: true,
-				plan: {
-					include: {
-						modules: {
-							include: {
-								module: true
-							}
-						}
-					}
-				},
-				assignmentGraded: true,
-				instructorProfile: true,
-				social: true
-			}
-		});
-	}
-
-	async usersByParam(input: UserFields): Promise<User[] | null> {
+	/**
+	 * Get users by params in input. If `openID` or `id` fields are set in the input, the returned user is guaranteed to be unique. If no params are provided, all users are returned.
+	 *
+	 */
+	async usersByParam(input: UserFields) {
 		const {
 			id,
 			openID,
@@ -79,57 +42,116 @@ export class UserService {
 			instructorProfile
 		} = input;
 
-		const payload = {
-			...(id && { id }),
-			...(openID && { openID }),
-			...(email && { email }),
-			...(picURL && { picURL }),
-			...(createdAt && { createdAt }),
-			...(firstName && { firstName }),
-			...(lastName && { lastName }),
-			...(middleName && { middleName }),
+		const include = Prisma.validator<Prisma.UserInclude>()({
+			feedback: true,
+			plan: {
+				include: {
+					modules: {
+						include: {
+							module: true
+						}
+					}
+				}
+			},
+			assignmentGraded: true,
+			instructorProfile: true,
+			social: true
+		});
+
+		const where = Prisma.validator<Prisma.UserWhereInput>()({
+			...(firstName && {
+				firstName: {
+					contains: firstName
+				}
+			}),
+			...(lastName && {
+				lastName: {
+					contains: lastName
+				}
+			}),
+			...(middleName && {
+				middleName: {
+					contains: middleName
+				}
+			}),
+			...(email && {
+				email: {
+					contains: email
+				}
+			}),
 			...(isAdmin && { isAdmin }),
 			...(isActive && { isActive }),
-			...(dob && { dob })
-		};
-
-		payload["socialId"] = social ? social : undefined;
-		payload["planId"] = plan ? plan : undefined;
-
-		if (feedback) {
-			payload["feedback"] = {
-				some: {
-					id: feedback
+			...(dob && { dob }),
+			...(picURL && { picURL }),
+			...(createdAt && { createdAt }),
+			...(id && { id }),
+			...(openID && { openID }),
+			...(social && {
+				social: {
+					id: social
 				}
-			};
-		}
-
-		if (assignmentGraded) {
-			payload["assignmentGraded"] = {
-				some: {
-					id: assignmentGraded
+			}),
+			...(plan && {
+				plan: {
+					id: plan
 				}
-			};
-		}
-
-		if (instructorProfile) {
-			payload["instructorProfile"] = {
-				some: {
+			}),
+			...(feedback && {
+				feedback: {
+					some: {
+						id: feedback
+					}
+				}
+			}),
+			...(assignmentGraded && {
+				assignmentGraded: {
+					some: {
+						id: assignmentGraded
+					}
+				}
+			}),
+			...(instructorProfile && {
+				instructorProfile: {
 					id: instructorProfile
 				}
-			};
+			})
+		});
+
+		let result:
+			| Array<
+					Prisma.UserGetPayload<{
+						include: Prisma.UserInclude;
+					}>
+			  >
+			| Error;
+
+		//find a unique user
+		//returns a single user
+		if (id || openID) {
+			const unique = Prisma.validator<Prisma.UserWhereUniqueInput>()({
+				...(id && { id }),
+				...(openID && { openID })
+			});
+			let res = await this.prisma.user.findUnique({
+				where: unique,
+				include
+			});
+			if (!res) return new Error("User not found");
+			else result = [res];
 		}
 
-		return await this.prisma.user.findMany({
-			where: payload,
-			include: {
-				social: true,
-				plan: true,
-				feedback: true,
-				assignmentGraded: true,
-				instructorProfile: true
-			}
-		});
+		//find many users by scalar fields
+		//returns an array of users
+		else {
+			let res = await this.prisma.user.findMany({
+				where,
+				include
+			});
+			if (!res) return new Error("User not found");
+			result = res;
+		}
+
+		return result;
 	}
 
 	/// Get all Social Records
@@ -177,15 +199,15 @@ export class UserService {
 	}
 
 	/// Get a specific Instructor's profile by user ID
-	async instructorProfile(id: string): Promise<InstructorProfile | null> {
-		return (await this.prisma.instructorProfile.findUnique({
+	async instructorProfile(id: string) {
+		return await this.prisma.instructorProfile.findUnique({
 			where: {
 				accountID: id
 			},
 			include: {
 				account: true
 			}
-		})) as InstructorProfile;
+		});
 	}
 
 	// Update a user
@@ -259,7 +281,9 @@ export class UserService {
 
 	// delete a user by id
 	async deleteUser(id: string): Promise<User | Error> {
-		const res = await this.user(id);
+		const res = await this.usersByParam({
+			id
+		});
 
 		if (res === null) {
 			return new Error(`The user with ${id}, does not exist`);

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -18,6 +18,22 @@ export class UserService {
 		this.prisma = prisma;
 	}
 
+	private includeUser = Prisma.validator<Prisma.UserInclude>()({
+		feedback: true,
+				plan: {
+					include: {
+						modules: {
+							include: {
+								module: true
+							}
+						}
+					}
+				},
+				assignmentGraded: true,
+				instructorProfile: true,
+				social: true,
+	});
+
 	/**
 	 * Get users by params in input. If `openID` or `id` fields are set in the input, the returned user is guaranteed to be unique. If no params are provided, all users are returned.
 	 *
@@ -41,22 +57,6 @@ export class UserService {
 			assignmentGraded,
 			instructorProfile
 		} = input;
-
-		const include = Prisma.validator<Prisma.UserInclude>()({
-			feedback: true,
-			plan: {
-				include: {
-					modules: {
-						include: {
-							module: true
-						}
-					}
-				}
-			},
-			assignmentGraded: true,
-			instructorProfile: true,
-			social: true
-		});
 
 		const where = Prisma.validator<Prisma.UserWhereInput>()({
 			...(firstName && {
@@ -134,7 +134,7 @@ export class UserService {
 			});
 			let res = await this.prisma.user.findUnique({
 				where: unique,
-				include
+				include: this.includeUser
 			});
 			if (!res) return new Error("User not found");
 			else result = [res];
@@ -145,7 +145,7 @@ export class UserService {
 		else {
 			let res = await this.prisma.user.findMany({
 				where,
-				include
+				include: this.includeUser
 			});
 			if (!res) return new Error("User not found");
 			result = res;
@@ -273,9 +273,7 @@ export class UserService {
 				...(isAdmin && { isAdmin }),
 				...(isActive && { isActive })
 			},
-			include: {
-				instructorProfile: true
-			}
+			include: this.includeUser
 		});
 	}
 

--- a/utils/tests.ts
+++ b/utils/tests.ts
@@ -1,0 +1,6 @@
+export const shuffle = (str) =>
+	[...str].sort(() => Math.random() - 0.5).join("");
+
+export const pickRandomFromArray = (arr: any[]): number => {
+	return Math.floor(Math.random() * arr.length);
+};


### PR DESCRIPTION
Now `user`, `users`, and `usersByParam` queries are combined into a single `user` query that uses the `usersByParam()` service under the hood. This allows the FE team to use just a single query and change the arguments based on the results they want to receive.

Verified ALMP-513