### PR TITLE
✨ (community): Merged queries to use single parameter based filter service

### DIFF
--- a/gql/graphql.ts
+++ b/gql/graphql.ts
@@ -37,7 +37,7 @@ export interface IThreadByParams {
     body?: Nullable<string>;
     parentLesson?: Nullable<string>;
     parentThread?: Nullable<string>;
-    comments?: Nullable<Nullable<string>[]>;
+    comments?: Nullable<string>;
     upvotes?: Nullable<number>;
     upvotesGTE?: Nullable<number>;
     upvotesLTE?: Nullable<number>;

--- a/gql/graphql.ts
+++ b/gql/graphql.ts
@@ -31,6 +31,19 @@ export interface ICommentCreateInput {
     author: string;
 }
 
+export interface IThreadByParams {
+    id?: Nullable<string>;
+    title?: Nullable<string>;
+    body?: Nullable<string>;
+    parentLesson?: Nullable<string>;
+    parentThread?: Nullable<string>;
+    comments?: Nullable<Nullable<string>[]>;
+    upvotes?: Nullable<number>;
+    upvotesGTE?: Nullable<number>;
+    upvotesLTE?: Nullable<number>;
+    author?: Nullable<string>;
+}
+
 export interface PlanInput {
     student?: Nullable<string>;
 }
@@ -334,8 +347,7 @@ export interface IMutation {
 
 export interface IQuery {
     refresh(token?: Nullable<string>): Nullable<string> | Promise<Nullable<string>>;
-    thread(id: string): Nullable<Thread> | Promise<Nullable<Thread>>;
-    threads(): Nullable<Thread>[] | Promise<Nullable<Thread>[]>;
+    thread(input?: Nullable<IThreadByParams>): Thread[] | Promise<Thread[]>;
     plan(studentID: string): Nullable<PlanOfStudy> | Promise<Nullable<PlanOfStudy>>;
     plans(): Nullable<PlanOfStudy[]> | Promise<Nullable<PlanOfStudy[]>>;
     planByID(id: string): Nullable<PlanOfStudy> | Promise<Nullable<PlanOfStudy>>;

--- a/src/community/community.resolver.ts
+++ b/src/community/community.resolver.ts
@@ -64,6 +64,8 @@ export class CommunityResolver {
 		@Args("id") id: string,
 		@Args("data") data: Prisma.ThreadUpdateInput
 	) {
-		return await this.communityService.updateThread(id, data);
+		const res = await this.communityService.updateThread(id, data);
+		if (!res || res instanceof Error) return new Error(res.message);
+		return res;
 	}
 }

--- a/src/community/community.resolver.ts
+++ b/src/community/community.resolver.ts
@@ -18,18 +18,15 @@ export class CommunityResolver {
 
 	@Query("thread")
 	async thread(@Args("input") input: IThreadByParams) {
-		const thread = await this.communityService.thread(input);
-		if (!thread || thread instanceof Error)
-			return new Error("Thread not found");
+		const thread = await this.communityService.threadsByParam(input);
+		if (thread instanceof Error) return new Error(thread.message);
 		else return thread;
 	}
 
 	@Mutation("createThread")
 	async createThread(@Args("data") data: IThreadCreateInput) {
 		const newThread = await this.communityService.createThread(data);
-		if (newThread instanceof Error) {
-			return new Error("Failed to create thread");
-		}
+		if (newThread instanceof Error) return new Error(newThread.message);
 		return newThread;
 	}
 
@@ -44,8 +41,7 @@ export class CommunityResolver {
 		@Args("data") data: ICommentCreateInput
 	) {
 		const self = await this.thread({ id });
-		if (!self || self instanceof Error)
-			return new Error("Parent thread to add comment to was not found");
+		if (self instanceof Error) return new Error(self.message);
 		else {
 			//creating new comment document
 			const newThread = await this.createThread({
@@ -53,9 +49,7 @@ export class CommunityResolver {
 				author: data.author,
 				parentThread: self[0].id
 			});
-			if (newThread instanceof Error) {
-				return new Error("Failed to add comment to thread");
-			}
+			if (newThread instanceof Error) return new Error(newThread.message);
 			return newThread;
 		}
 	}

--- a/src/community/community.service.ts
+++ b/src/community/community.service.ts
@@ -202,16 +202,20 @@ export class CommunityService {
 
 	async updateThread(id: string, data: Prisma.ThreadUpdateInput) {
 		const { title, body } = data;
-		return await this.prisma.thread.update({
-			where: {
-				id
-			},
-			data: {
-				...(title && { title }),
-				...(body && { body })
-			},
-			include: this.threadInclude
-		});
+		try {
+			return await this.prisma.thread.update({
+				where: {
+					id
+				},
+				data: {
+					...(title && { title }),
+					...(body && { body })
+				},
+				include: this.threadInclude
+			});
+		} catch (e: any) {
+			return new Error(e);
+		}
 	}
 
 	async deleteThread(id: string) {

--- a/src/community/community.service.ts
+++ b/src/community/community.service.ts
@@ -30,7 +30,7 @@ export class CommunityService {
 			parentLesson,
 			parentThread,
 			author,
-			// comments,
+			comments,
 			upvotes,
 			upvotesGTE,
 			upvotesLTE
@@ -74,6 +74,15 @@ export class CommunityService {
 			...(upvotesLTE && {
 				upvotes: {
 					lte: upvotesLTE
+				}
+			}),
+			...(comments && {
+				comments: {
+					some: {
+						id: {
+							in: comments
+						}
+					}
 				}
 			})
 		});

--- a/src/community/community.service.ts
+++ b/src/community/community.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { PrismaService } from "@/prisma.service";
 import { Prisma } from "@prisma/client";
-import { IThreadCreateInput, Thread } from "@/types/graphql";
+import { IThreadByParams, IThreadCreateInput } from "@/types/graphql";
 
 @Injectable()
 export class CommunityService {
@@ -22,19 +22,99 @@ export class CommunityService {
 		author: true
 	});
 
-	async threads() {
-		return await this.prisma.thread.findMany({
-			include: this.threadInclude
-		});
-	}
+	async thread(input: IThreadByParams) {
+		const {
+			id,
+			title,
+			body,
+			parentLesson,
+			parentThread,
+			author,
+			// comments,
+			upvotes,
+			upvotesGTE,
+			upvotesLTE
+		} = input;
 
-	async thread(id: string) {
-		return await this.prisma.thread.findUnique({
-			where: {
-				id
-			},
-			include: this.threadInclude
+		const where = Prisma.validator<Prisma.ThreadWhereInput>()({
+			...(id && { id }),
+			...(title && {
+				title: {
+					contains: title
+				}
+			}),
+			...(body && {
+				body: {
+					contains: body
+				}
+			}),
+			...(parentLesson && {
+				parentLesson: {
+					id: parentLesson
+				}
+			}),
+			...(parentThread && {
+				parentThread: {
+					id: parentThread
+				}
+			}),
+			...(author && {
+				author: {
+					id: author
+				}
+			}),
+			// ...(comments && {
+			// 	comments: {
+			// 		some: {
+			// 			id: comments
+			// 		}
+			// 	}
+			// }),
+			...(upvotes && {
+				upvotes
+			}),
+			...(upvotesGTE && {
+				upvotes: {
+					gte: upvotesGTE
+				}
+			}),
+			...(upvotesLTE && {
+				upvotes: {
+					lte: upvotesLTE
+				}
+			})
 		});
+
+		let include = this.threadInclude;
+
+		let res:
+			| Array<
+					Prisma.ThreadGetPayload<{
+						include: typeof include;
+					}>
+			  >
+			| Error;
+
+		if (id) {
+			const unique = Prisma.validator<Prisma.ThreadWhereUniqueInput>()({
+				id
+			});
+			const response = await this.prisma.thread.findUnique({
+				where: unique,
+				include: this.threadInclude
+			});
+			if (!response || response instanceof Error)
+				return new Error("Thread not found");
+			res = [response];
+		} else {
+			res = await this.prisma.thread.findMany({
+				where,
+				include: this.threadInclude
+			});
+		}
+
+		if (!res) return new Error("Thread not found");
+		else return res;
 	}
 
 	async createThread(data: IThreadCreateInput) {
@@ -75,81 +155,6 @@ export class CommunityService {
 				author: true
 			}
 		});
-	}
-
-	async addCommentToThread(
-		id: string,
-		comments: Thread[] & {
-			comments: Array<(Thread & { comments: Thread[] }) | []>;
-		},
-		data: Thread
-	) {
-		console.log({
-			id,
-			comments,
-			data
-		});
-
-		if (comments.length === 0) {
-			const update = Prisma.validator<Prisma.ThreadUpdateInput>()({
-				comments: {
-					connect: {
-						id: data.id
-					}
-				}
-			});
-
-			return await this.prisma.thread.update({
-				where: {
-					id
-				},
-				data: update
-			});
-		} else {
-			const newComments = comments.concat(data);
-
-			console.log(newComments);
-
-			const update = Prisma.validator<Prisma.ThreadUpdateInput>()({});
-
-			return await this.prisma.thread.update({
-				where: {
-					id
-				},
-				data: update
-			});
-		}
-
-		// if (comments.length > 0) {
-		// 	//save old comments
-		// 	//append new comment
-		// 	//set new comments
-		// } else {
-		// 	return await this.prisma.thread.update({
-		// 		where: {
-		// 			id
-		// 		},
-		// 		data: {
-		// 			comments: {
-		// 				set: [newComment]
-		// 			}
-		// 		}
-		// 	});
-		// }
-
-		// return await this.prisma.thread.update({
-		// 	where: {
-		// 		id
-		// 	},
-		// 	data: {
-		// 		comments: {
-		// 			//TODO: fix this with the prisma validator so we can stop using ignore
-		//
-		// 			// @ts-ignore
-		// 			push: data
-		// 		}
-		// 	}
-		// });
 	}
 
 	async upvoteThread(id: string) {

--- a/src/community/community.service.ts
+++ b/src/community/community.service.ts
@@ -140,8 +140,6 @@ export class CommunityService {
 			});
 		}
 
-		console.log(where);
-
 		if (!res) return new Error("Thread not found");
 		else return res;
 	}
@@ -150,7 +148,9 @@ export class CommunityService {
 		const { title, body, parentLesson, parentThread, author } = data;
 
 		const create = Prisma.validator<Prisma.ThreadCreateInput>()({
-			title,
+			...(title && {
+				title
+			}),
 			body,
 			author: {
 				connect: {
@@ -178,11 +178,12 @@ export class CommunityService {
 			}
 		});
 
+		if (!parentThread && !title)
+			return new Error("Parent thread ID is required for comments.");
+
 		return await this.prisma.thread.create({
 			data: create,
-			include: {
-				author: true
-			}
+			include: this.threadInclude
 		});
 	}
 
@@ -208,7 +209,8 @@ export class CommunityService {
 			data: {
 				...(title && { title }),
 				...(body && { body })
-			}
+			},
+			include: this.threadInclude
 		});
 	}
 

--- a/src/community/community.spec.ts
+++ b/src/community/community.spec.ts
@@ -77,110 +77,153 @@ describe("Community", () => {
 	it("should be defined", () => {
 		expect(resolver).toBeDefined();
 	});
-	it("should return all threads if no params are inputted", async () => {
-		const threads = await resolver.thread({});
-		expect(threads).toBeInstanceOf(Array);
-		if (threads instanceof Error) return new Error(threads.message);
-		else {
-			testingThreadDoc = threads[pickRandomFromArray(threads)];
+	describe("Param based querying", function () {
+		it("should return all threads if no params are inputted", async () => {
+			const threads = await resolver.thread({});
+			expect(threads).toBeInstanceOf(Array);
+			if (threads instanceof Error) return new Error(threads.message);
+			else {
+				testingThreadDoc = threads[pickRandomFromArray(threads)];
 
-			testingThreadID = testingThreadDoc.id;
-			deletableThreadIDs.push(testingThreadID);
-			expect(testingThreadDoc.comments).toBeInstanceOf(Array);
-			expect(testingThreadDoc.usersWatching).toBeInstanceOf(Array);
-			expect(testingThreadDoc.author).toBeInstanceOf(Object);
-		}
-	});
-	it("should return an error when ID is not found", async () => {
-		const thread = await resolver.thread({ id: shuffle(testingThreadID) });
-		expect(thread instanceof Error).toBe(true);
-	});
-	it("should return threads with less upvotes than inputted", async () => {
-		const threads = await resolver.thread({ upvotesLTE: 100 });
-		if (threads instanceof Error) return new Error(threads.message);
-		else {
-			threads.map((thread) => {
-				expect(thread.upvotes < 100).toBe(true);
+				testingThreadID = testingThreadDoc.id;
+				deletableThreadIDs.push(testingThreadID);
+				expect(testingThreadDoc.comments).toBeInstanceOf(Array);
+				expect(testingThreadDoc.usersWatching).toBeInstanceOf(Array);
+				expect(testingThreadDoc.author).toBeInstanceOf(Object);
+			}
+		});
+		it("should return an error when ID is not found", async () => {
+			const thread = await resolver.thread({ id: shuffle(testingThreadID) });
+			expect(thread instanceof Error).toBe(true);
+		});
+		it("should return threads with less upvotes than inputted", async () => {
+			const threads = await resolver.thread({ upvotesLTE: 100 });
+			if (threads instanceof Error) return new Error(threads.message);
+			else {
+				threads.map((thread) => {
+					expect(thread.upvotes < 100).toBe(true);
+				});
+			}
+		});
+		it("should return threads with more upvotes than inputted", async () => {
+			const threads = await resolver.thread({ upvotesGTE: 100 });
+			if (threads instanceof Error) return new Error(threads.message);
+			else {
+				threads.map((thread) => {
+					expect(thread.upvotes > 100).toBe(true);
+				});
+			}
+		});
+		it("should return the threads requested by ID", async () => {
+			const thread = await resolver.thread({ id: testingThreadID });
+			if (!thread || thread instanceof Error)
+				return new Error("Thread not found");
+			else {
+				thread.map((thread) => {
+					expect(thread.id).toBe(testingThreadID);
+				});
+			}
+		});
+		it("should search for range if both GTE and LTE are given", async () => {
+			const threads = await resolver.thread({
+				upvotesGTE: 100,
+				upvotesLTE: 1000
 			});
-		}
-	});
-	it("should return threads with more upvotes than inputted", async () => {
-		const threads = await resolver.thread({ upvotesGTE: 100 });
-		if (threads instanceof Error) return new Error(threads.message);
-		else {
-			threads.map((thread) => {
-				expect(thread.upvotes > 100).toBe(true);
+			if (threads instanceof Error) return new Error(threads.message);
+			else {
+				threads.map((thread) => {
+					expect(thread.upvotes >= 100 && thread.upvotes <= 1000).toBe(true);
+				});
+			}
+		});
+		it("should return Error if both GTE and upvotes are given", async () => {
+			const threads = await resolver.thread({
+				upvotesGTE: 100,
+				upvotes: 1000
 			});
-		}
+			expect(threads instanceof Error).toBe(true);
+		});
 	});
-	it("should return the threads requested by ID", async () => {
-		const thread = await resolver.thread({ id: testingThreadID });
-		if (!thread || thread instanceof Error)
-			return new Error("Thread not found");
-		else {
-			thread.map((thread) => {
-				expect(thread.id).toBe(testingThreadID);
+	describe("Create", function () {
+		it("should create a thread with author", async () => {
+			const account = await createUser();
+			if ("id" in account) {
+				const thread = await createThread({
+					title: "This is a test thread",
+					body: "We are inserting this data from a test case, and this data should have been removed after the test case has finished.",
+					author: account.id
+				});
+				if (thread instanceof Error) return new Error(thread.message);
+				threadID = thread.id;
+				accountID = account.id;
+				deletableThreadIDs.push(threadID);
+				expect(thread).toHaveProperty("title");
+				expect(thread).toHaveProperty("body");
+				expect(thread).toHaveProperty("author");
+				expect(thread.author.id === account.id).toBe(true);
+				expect(thread.watcherID.includes(account.id)).toBe(true);
+				expect(thread.parentThreadID).toBeNull();
+				expect(thread.parentLessonID).toBeNull();
+				expect(thread.author.watchedThreadIDs.includes(thread.id)).toBe(true);
+			}
+		});
+		it("should add comment with author as watcher", async () => {
+			const res = await resolver.addCommentToThread(threadID, {
+				body: "How does this look?",
+				author: accountID
 			});
-		}
+			if (res instanceof Error) return new Error(res.message);
+			else {
+				deletableThreadIDs.push(res.id);
+				expect(res.author.id === accountID).toBe(true);
+				expect(res.watcherID.includes(accountID)).toBe(true);
+				expect(res.parentThreadID === threadID).toBe(true);
+			}
+		});
+		it("should fail to add comment if parent ID is not found", async () => {
+			const thread = await resolver.addCommentToThread(shuffle(threadID), {
+				body: "How does this look?",
+				author: accountID
+			});
+			expect(thread instanceof Error).toBe(true);
+		});
+		it("should not create comment if parent thread is not given", async () => {
+			const falseComment = await resolver.createThread({
+				body: "This comment should not be created as the parent thread is not given",
+				author: accountID
+			});
+			expect(falseComment instanceof Error).toBe(true);
+		});
 	});
-	it("should create a thread with author", async () => {
-		const account = await createUser();
-		if ("id" in account) {
-			const thread = await createThread({
-				title: "This is a test thread",
-				body: "We are inserting this data from a test case, and this data should have been removed after the test case has finished.",
-				author: account.id
+	describe("Update", function () {
+		it("should increase vote count by 1", async () => {
+			const voteNum = await resolver.thread({ id: threadID });
+			if (voteNum instanceof Error)
+				throw new Error("Error in upvoteThread test case");
+
+			const upVoteNum = await resolver.upvoteThread(threadID);
+			if (upVoteNum instanceof Error)
+				throw new Error("Error in upvoteThread test case");
+
+			expect(upVoteNum.upvotes === voteNum[0].upvotes + 1).toBe(true);
+		});
+		it("should update the thread with the given data", async () => {
+			const thread = await resolver.updateThread(threadID, {
+				title: "This is an updated thread",
+				body: "Is this thread updatable?"
 			});
 			if (thread instanceof Error) return new Error(thread.message);
-			threadID = thread.id;
-			accountID = account.id;
-			deletableThreadIDs.push(threadID);
-			expect(thread).toHaveProperty("title");
-			expect(thread).toHaveProperty("body");
-			expect(thread).toHaveProperty("author");
-			expect(thread.author.id === account.id).toBe(true);
-			expect(thread.watcherID.includes(account.id)).toBe(true);
-			expect(thread.parentThreadID).toBeNull();
-			expect(thread.parentLessonID).toBeNull();
-			expect(thread.author.watchedThreadIDs.includes(thread.id)).toBe(true);
-		}
-	});
-	it("should add comment with author as watcher", async () => {
-		const res = await resolver.addCommentToThread(threadID, {
-			body: "How does this look?",
-			author: accountID
+			else {
+				expect(thread.title).toBe("This is an updated thread");
+				expect(thread.body).toBe("Is this thread updatable?");
+			}
 		});
-		if (res instanceof Error) return new Error(res.message);
-		else {
-			deletableThreadIDs.push(res.id);
-			expect(res.author.id === accountID).toBe(true);
-			expect(res.watcherID.includes(accountID)).toBe(true);
-			expect(res.parentThreadID === threadID).toBe(true);
-		}
-	});
-	it("should fail to add comment if parent ID is not found", async () => {
-		const thread = await resolver.addCommentToThread(shuffle(threadID), {
-			body: "How does this look?",
-			author: accountID
+		it("should return Error if ID was not found", async () => {
+			const thread = await resolver.updateThread(shuffle(threadID), {
+				title: "This is an updated thread",
+				body: "Is this thread updatable?"
+			});
+			expect(thread instanceof Error).toBe(true);
 		});
-		expect(thread instanceof Error).toBe(true);
-	});
-	it("should handle a thread and ensure that the vote count has increased by 1", async () => {
-		const voteNum = await resolver.thread({ id: threadID });
-		if (voteNum instanceof Error)
-			throw new Error("Error in upvoteThread test case");
-
-		const upVoteNum = await resolver.upvoteThread(threadID);
-		if (upVoteNum instanceof Error)
-			throw new Error("Error in upvoteThread test case");
-
-		expect(upVoteNum.upvotes === voteNum[0].upvotes + 1).toBe(true);
-	});
-	it("should not create comment if parent thread is not given", async () => {
-		const falseComment = await resolver.createThread({
-			body: "This comment should not be created as the parent thread is not given",
-			author: accountID
-		});
-		expect(falseComment instanceof Error).toBe(true);
 	});
 });

--- a/src/community/community.spec.ts
+++ b/src/community/community.spec.ts
@@ -218,12 +218,29 @@ describe("Community", () => {
 				expect(thread.body).toBe("Is this thread updatable?");
 			}
 		});
-		it("should return Error if ID was not found", async () => {
+		it("should return Error if update ID was not found", async () => {
 			const thread = await resolver.updateThread(shuffle(threadID), {
 				title: "This is an updated thread",
 				body: "Is this thread updatable?"
 			});
 			expect(thread instanceof Error).toBe(true);
+		});
+	});
+	describe("Delete", function () {
+		it("should delete the thread", async () => {
+			const tempThread = await createThread({
+				title: "This is testing the delete thread function",
+				body: "This should not be seen by anyone",
+				author: accountID
+			});
+			if (tempThread instanceof Error) return new Error(tempThread.message);
+			else {
+				const thread = await resolver.deleteThread(tempThread.id);
+				if (thread instanceof Error) return new Error(thread.message);
+				expect(thread instanceof Error).toBe(false);
+				const findDeleted = await resolver.thread({ id: tempThread.id });
+				expect(findDeleted instanceof Error).toBe(true);
+			}
 		});
 	});
 });

--- a/src/community/schema.graphql
+++ b/src/community/schema.graphql
@@ -60,15 +60,45 @@ input ICommentCreateInput {
 }
 
 input IThreadByParams {
+    """
+    The ID of the thread to be exactly equal to the given value. If this parameter is given, all other parameters are ignored. The returned thread is guaranteed to be unique, but still returned as an array.
+    """
     id: ID
+    """
+    The title of the thread to be partially matched to the given value. Upper and lower case characters are not treated equally.
+    """
     title: String
+    """
+    The content body of the thread to be partially matched to the given value. Upper and lower case characters are not treated equally.
+    """
     body: String
+    """
+    The ID of the lesson to be exactly equal to the given value.
+    """
     parentLesson: ID
+    """
+    The ID of the parent thread to be exactly equal to the given value.
+    """
     parentThread: ID
+    """
+    The ID of a comment to be exactly equal to the given value. The query will look through all Threads that are comments and return the parent thread and the entire comments array that matches the given ID.
+    """
     comments: ID
+    """
+    The number of upvotes for the thread to be exactly equal to the given value. If this parameter is given, upvotesGTE and upvotesLTE are ignored. If this parameter has a value of 0, the parameter is ignored.
+    """
     upvotes: Int
+    """
+    The number of upvotes for the thread to be greater than or equal to the given value. If this parameter is given, upvotes is ignored. This parameter can be used in conjunction with upvotesLTE to create a range based search.
+    """
     upvotesGTE: Int
+    """
+    The number of upvotes for the thread to be less than or equal to the given value. If this parameter is given, upvotes is ignored. This parameter can be used in conjunction with upvotesGTE to create a range based search.
+    """
     upvotesLTE: Int
+    """
+    The ID of the user to be exactly equal to the given value.
+    """
     author: ID
 }
 

--- a/src/community/schema.graphql
+++ b/src/community/schema.graphql
@@ -65,7 +65,7 @@ input IThreadByParams {
     body: String
     parentLesson: ID
     parentThread: ID
-    comments: [ID]
+    comments: ID
     upvotes: Int
     upvotesGTE: Int
     upvotesLTE: Int

--- a/src/community/schema.graphql
+++ b/src/community/schema.graphql
@@ -59,15 +59,24 @@ input ICommentCreateInput {
     author: ID!
 }
 
+input IThreadByParams {
+    id: ID
+    title: String
+    body: String
+    parentLesson: ID
+    parentThread: ID
+    comments: [ID]
+    upvotes: Int
+    upvotesGTE: Int
+    upvotesLTE: Int
+    author: ID
+}
+
 type Query {
     """
-    Get a thread by ID
+    Get a list of threads that match the given parameters. If no parameters are given, all threads are returned. If the id parameter is given, the returned thread is guaranteed to be unique.
     """
-    thread(id: ID!): Thread
-    """
-    Get a list of threads
-    """
-    threads: [Thread]!
+    thread(input: IThreadByParams): [Thread!]!
 }
 
 type Mutation {

--- a/src/community/schema.graphql
+++ b/src/community/schema.graphql
@@ -31,7 +31,7 @@ type Thread {
     """
     usersWatching: [User!]
     """
-    TODO: Add linkage between lesson and thread once lesson schema is defined
+    Add linkage between lesson and thread once lesson schema is defined
     """
     parentLesson: Lesson
     """
@@ -47,15 +47,36 @@ type Thread {
 }
 
 input IThreadCreateInput {
+    """
+    The title of the thread. If this parameter is not given, the thread will be created as a comment to another thread, but only if the parentThread parameter is given. If this parameter is not given, the thread will be created as a new thread.
+    """
     title: String
+    """
+    The content body of the thread. Currently only supports text.
+    """
     body: String!
+    """
+    The ID of the lesson that this thread belongs to. If this parameter is not given, the thread will be created as a general social community post.
+    """
     parentLesson: ID
+    """
+    The ID of the parent thread that this comment belongs to. If this parameter is not given, the thread will be created as a new thread, and not as a comment. If this parameter is not given, the title parameter must be given.
+    """
     parentThread: ID
+    """
+    The ID of the user that is creating the thread. The thread's ID will be added to the user's list of watched threads.
+    """
     author: ID!
 }
 
 input ICommentCreateInput {
+    """
+    The content body of the comment. Currently only supports text.
+    """
     body: String!
+    """
+    The ID of the user that is creating the comment. The comment's ID will be added to the user's list of watched threads.
+    """
     author: ID!
 }
 

--- a/src/prisma.service.ts
+++ b/src/prisma.service.ts
@@ -1,9 +1,59 @@
-import { INestApplication, Injectable, OnModuleInit } from "@nestjs/common";
-import { PrismaClient } from "@prisma/client";
+import {
+	INestApplication,
+	Injectable,
+	Logger,
+	OnModuleInit
+} from "@nestjs/common";
+import { Prisma, PrismaClient } from "@prisma/client";
 
 @Injectable()
-export class PrismaService extends PrismaClient implements OnModuleInit {
+export class PrismaService
+	extends PrismaClient<
+		Prisma.PrismaClientOptions,
+		"query" | "error" | "info" | "warn"
+	>
+	implements OnModuleInit
+{
+	private readonly logger = new Logger(PrismaService.name);
+	constructor() {
+		super({
+			log: [
+				{
+					emit: "event",
+					level: "query"
+				},
+				{
+					emit: "event",
+					level: "error"
+				},
+				{
+					emit: "event",
+					level: "info"
+				},
+				{
+					emit: "event",
+					level: "warn"
+				}
+			],
+			errorFormat: "pretty"
+		});
+	}
+
 	async onModuleInit() {
+		process.env.NODE_ENV === "development" &&
+			this.$on("query", (e) => {
+				let cleanedQuery = JSON.stringify(e.query);
+				this.logger.log(JSON.parse(cleanedQuery));
+			});
+		this.$on("error", (e) => {
+			this.logger.error(e);
+		});
+		this.$on("info", (e) => {
+			this.logger.log(e);
+		});
+		this.$on("warn", (e) => {
+			this.logger.warn(e);
+		});
 		await this.$connect();
 	}
 


### PR DESCRIPTION
Now the FE team can use the `thread` query with its appropriate input parameters to find many or find unique Thread documents. In addition to the base properties that the Thread model has, the input argument also exposes "greater than" and "less than" fields that expand the allowed filtering of documents.

Verified ALMP-512