### PR TITLE
Added role filter on members for module query

### DIFF
--- a/gql/graphql.ts
+++ b/gql/graphql.ts
@@ -7,7 +7,6 @@
 
 /* tslint:disable */
 /* eslint-disable */
-
 export enum UserRole {
     STUDENT = "STUDENT",
     TEACHER = "TEACHER",
@@ -354,7 +353,7 @@ export interface IQuery {
     plans(): Nullable<PlanOfStudy[]> | Promise<Nullable<PlanOfStudy[]>>;
     planByID(id: string): Nullable<PlanOfStudy> | Promise<Nullable<PlanOfStudy>>;
     planByParams(input?: Nullable<PlanFields>): Nullable<PlanOfStudy[]> | Promise<Nullable<PlanOfStudy[]>>;
-    module(input: ModuleFields): Nullable<Module[]> | Promise<Nullable<Module[]>>;
+    module(input: ModuleFields, memberRole?: Nullable<UserRole>): Nullable<Module[]> | Promise<Nullable<Module[]>>;
     course(input: CourseFields): Nullable<Course[]> | Promise<Nullable<Course[]>>;
     assignment(input: AssignmentFields): Nullable<Assignment[]> | Promise<Nullable<Assignment[]>>;
     moduleFeedback(input: ModFeedbackFields): Nullable<ModuleFeedback[]> | Promise<Nullable<ModuleFeedback[]>>;

--- a/src/program/program.resolver.ts
+++ b/src/program/program.resolver.ts
@@ -21,7 +21,7 @@ import {
 } from "gql/graphql";
 import { Args, Mutation, Query, Resolver } from "@nestjs/graphql";
 import { ProgramService } from "./program.service";
-import { Prisma } from "@prisma/client";
+import { Prisma, UserRole } from "@prisma/client";
 import { UseGuards } from "@nestjs/common";
 import { AuthGuard } from "@/auth.guard";
 
@@ -32,8 +32,19 @@ export class ProgramResolver {
 
 	// Get Module(s)
 	@Query("module")
-	async module(@Args("input") args: ModuleFields) {
-		return await this.programService.module(args);
+	async module(@Args("input") args: ModuleFields, @Args("memberRole") role: UserRole) {
+		const result = await this.programService.module(args);
+		if (!role) {
+			return result;
+		} else {
+			const filterRes = result.map((module) =>{
+				let thisModule = module;
+				thisModule.members = module.members.filter((value) => value.role === role);
+				return thisModule;
+			});
+
+			return filterRes;
+		}
 	}
 
 	// Get Course(s)

--- a/src/program/schema.graphql
+++ b/src/program/schema.graphql
@@ -346,8 +346,9 @@ type Query {
 	"""
 	Get a list of modules given a set of parameters, passing an empty object in will recieve all and passing in an id will fetch a single document.
 	Parameters can be any of the fields that exist in a module
+	An additional parameter: memberRole, can be provided to specify that module members should only be selected if they have said role.
 	"""
-	module(input: ModuleFields!): [Module!]
+	module(input: ModuleFields!, memberRole: UserRole): [Module!]
 
 	"""
 	Get a list of courses given a set of parameters, passing an empty object in will recieve all and passing in an id will fetch a single document.
@@ -387,10 +388,10 @@ type Query {
 	Retrieve a specific collection based on document ID
 	"""
 	collection(id: ID!): Collection
-  """
-  Retrieve lessons given a set of parameters
-  """
-  lesson(input: LessonFields): [Lesson!]
+	"""
+	Retrieve lessons given a set of parameters
+	"""
+	lesson(input: LessonFields): [Lesson!]
 
 	"""
 	Retrieve Content Given a set of parameters


### PR DESCRIPTION
When querying for a module an optional `memberRole` parameter has been added. This will allow for filtration of the results of the enrollment to only display members with specific roles such as `GRADER`, `TEACHER`, or `STUDENT`