### PR TITLE
feat(community): Thread query now has null as default input value

### DIFF
--- a/src/community/community.resolver.ts
+++ b/src/community/community.resolver.ts
@@ -17,7 +17,7 @@ export class CommunityResolver {
 	}
 
 	@Query("thread")
-	async thread(@Args("input") input: IThreadByParams) {
+	async thread(@Args("input") input: IThreadByParams | null = null) {
 		const thread = await this.communityService.threadsByParam(input);
 		if (thread instanceof Error) return new Error(thread.message);
 		else return thread;
@@ -58,7 +58,6 @@ export class CommunityResolver {
 	async upvoteThread(@Args("id") id: string) {
 		return await this.communityService.upvoteThread(id);
 	}
-
 
 	@Mutation("updateThread")
 	async updateThread(

--- a/src/community/community.service.ts
+++ b/src/community/community.service.ts
@@ -1,7 +1,11 @@
 import { Injectable } from "@nestjs/common";
 import { PrismaService } from "@/prisma.service";
 import { Prisma } from "@prisma/client";
-import { IThreadByParams, IThreadCreateInput, ICommentCreateInput } from "@/types/graphql";
+import {
+	IThreadByParams,
+	IThreadCreateInput,
+	ICommentCreateInput
+} from "@/types/graphql";
 
 @Injectable()
 export class CommunityService {
@@ -22,126 +26,132 @@ export class CommunityService {
 		author: true
 	});
 
-	async threadsByParam(input: IThreadByParams) {
-		const {
-			id,
-			title,
-			body,
-			parentLesson,
-			parentThread,
-			author,
-			comments,
-			upvotes,
-			upvotesGTE,
-			upvotesLTE
-		} = input;
+	async threadsByParam(input?: IThreadByParams | null) {
+		if (!input) {
+			return this.prisma.thread.findMany({
+				include: this.threadInclude
+			});
+		} else {
+			const {
+				id,
+				title,
+				body,
+				parentLesson,
+				parentThread,
+				author,
+				comments,
+				upvotes,
+				upvotesGTE,
+				upvotesLTE
+			} = input;
 
-		const where = Prisma.validator<Prisma.ThreadWhereInput>()({
-			...(id && { id }),
-			...(title && {
-				title: {
-					contains: title
-				}
-			}),
-			...(body && {
-				body: {
-					contains: body
-				}
-			}),
-			...(parentLesson && {
-				parentLesson: {
-					id: parentLesson
-				}
-			}),
-			...(parentThread && {
-				parentThread: {
-					id: parentThread
-				}
-			}),
-			...(author && {
-				author: {
-					id: author
-				}
-			}),
-			...(upvotes && {
-				upvotes
-			}),
-			...(upvotesGTE && {
-				upvotes: {
-					gte: upvotesGTE
-				}
-			}),
-			...(upvotesLTE && {
-				upvotes: {
-					lte: upvotesLTE
-				}
-			}),
-			...(comments && {
-				comments: {
-					some: {
-						id: {
-							in: comments
-						}
+			const where = Prisma.validator<Prisma.ThreadWhereInput>()({
+				...(id && { id }),
+				...(title && {
+					title: {
+						contains: title
 					}
-				}
-			})
-		});
-
-		// if both upvotes and upvotesGTE or upvotesLTE are provided, we need to throw an error since we cannot filter for exact number and range at the same time
-		if (
-			(typeof upvotes === "number" && typeof upvotesGTE === "number") ||
-			(typeof upvotes === "number" && typeof upvotesLTE === "number")
-		)
-			return new Error(
-				"Cannot use upvotes and upvotesGTE or upvotesLTE at the same time"
-			);
-
-		// if both upvotesGTE and upvotesLTE are provided, we need to use AND to get the range
-		if (typeof upvotesGTE === "number" && typeof upvotesLTE === "number") {
-			delete where["upvotes"];
-			where["AND"] = [
-				{
+				}),
+				...(body && {
+					body: {
+						contains: body
+					}
+				}),
+				...(parentLesson && {
+					parentLesson: {
+						id: parentLesson
+					}
+				}),
+				...(parentThread && {
+					parentThread: {
+						id: parentThread
+					}
+				}),
+				...(author && {
+					author: {
+						id: author
+					}
+				}),
+				...(upvotes && {
+					upvotes
+				}),
+				...(upvotesGTE && {
 					upvotes: {
 						gte: upvotesGTE
 					}
-				},
-				{
+				}),
+				...(upvotesLTE && {
 					upvotes: {
 						lte: upvotesLTE
 					}
-				}
-			] as Prisma.ThreadWhereInput["AND"];
-		}
-
-		const include = this.threadInclude;
-
-		let res:
-			| Array<
-					Prisma.ThreadGetPayload<{
-						include: typeof include;
-					}>
-			  >
-			| Error;
-
-		if (id) {
-			const response = await this.prisma.thread.findUnique({
-				where: {
-					id
-				},
-				include: this.threadInclude
+				}),
+				...(comments && {
+					comments: {
+						some: {
+							id: {
+								in: comments
+							}
+						}
+					}
+				})
 			});
-			if (!response || response instanceof Error)
-				return new Error("Thread not found");
-			res = [response];
-		} else {
-			res = await this.prisma.thread.findMany({
-				where,
-				include: this.threadInclude
-			});
-		}
 
-		if (!res) return new Error("Thread not found");
-		else return res;
+			// if both upvotes and upvotesGTE or upvotesLTE are provided, we need to throw an error since we cannot filter for exact number and range at the same time
+			if (
+				(typeof upvotes === "number" && typeof upvotesGTE === "number") ||
+				(typeof upvotes === "number" && typeof upvotesLTE === "number")
+			)
+				return new Error(
+					"Cannot use upvotes and upvotesGTE or upvotesLTE at the same time"
+				);
+
+			// if both upvotesGTE and upvotesLTE are provided, we need to use AND to get the range
+			if (typeof upvotesGTE === "number" && typeof upvotesLTE === "number") {
+				delete where["upvotes"];
+				where["AND"] = [
+					{
+						upvotes: {
+							gte: upvotesGTE
+						}
+					},
+					{
+						upvotes: {
+							lte: upvotesLTE
+						}
+					}
+				] as Prisma.ThreadWhereInput["AND"];
+			}
+
+			const include = this.threadInclude;
+
+			let res:
+				| Array<
+						Prisma.ThreadGetPayload<{
+							include: typeof include;
+						}>
+				  >
+				| Error;
+
+			if (id) {
+				const response = await this.prisma.thread.findUnique({
+					where: {
+						id
+					},
+					include: this.threadInclude
+				});
+				if (!response || response instanceof Error)
+					return new Error("Thread not found");
+				res = [response];
+			} else {
+				res = await this.prisma.thread.findMany({
+					where,
+					include: this.threadInclude
+				});
+			}
+
+			if (!res) return new Error("Thread not found");
+			else return res;
+		}
 	}
 
 	async createThread(data: IThreadCreateInput) {
@@ -203,16 +213,16 @@ export class CommunityService {
 	async updateThread(id: string, data: Prisma.ThreadUpdateInput) {
 		const { title, body } = data;
 		try {
-      const update = Prisma.validator<Prisma.ThreadUpdateArgs>()({
-			  where: {
-				  id
-			  },
-			  data: {
-				  ...(title && { title }),
-				  ...(body && { body })
-			  }
-		  })
-		  return await this.prisma.thread.update(update);
+			const update = Prisma.validator<Prisma.ThreadUpdateArgs>()({
+				where: {
+					id
+				},
+				data: {
+					...(title && { title }),
+					...(body && { body })
+				}
+			});
+			return await this.prisma.thread.update(update);
 		} catch (e: any) {
 			return new Error(e);
 		}
@@ -225,29 +235,30 @@ export class CommunityService {
 			}
 		});
 	}
-  
-  async addCommentToThread(parentThreadID: string, data: ICommentCreateInput) {
-        if(!data.id){
-            throw new Error("Comment ID is required to connect to parent thread. There was an error creating your initial comment, if this error is shown.")
-        }
-        const update = Prisma.validator<Prisma.ThreadUncheckedUpdateInput>()({
-            comments: {
-                connect: {
-                    id: data.id
-                }
-            }
-        })
-        console.log(update);
-        return await this.prisma.thread.update({
-            where: {
-                id: parentThreadID
-            },
-            data: update,
-            include: {
-                comments: true,
-                author: true
-            }
-        })
-    }
-  
+
+	async addCommentToThread(parentThreadID: string, data: ICommentCreateInput) {
+		if (!data.id) {
+			throw new Error(
+				"Comment ID is required to connect to parent thread. There was an error creating your initial comment, if this error is shown."
+			);
+		}
+		const update = Prisma.validator<Prisma.ThreadUncheckedUpdateInput>()({
+			comments: {
+				connect: {
+					id: data.id
+				}
+			}
+		});
+		console.log(update);
+		return await this.prisma.thread.update({
+			where: {
+				id: parentThreadID
+			},
+			data: update,
+			include: {
+				comments: true,
+				author: true
+			}
+		});
+	}
 }

--- a/src/community/community.spec.ts
+++ b/src/community/community.spec.ts
@@ -78,8 +78,8 @@ describe("Community", () => {
 		expect(resolver).toBeDefined();
 	});
 	describe("Param based querying", function () {
-		it("should return all threads if no params are inputted", async () => {
-			const threads = await resolver.thread({});
+		it("should return all threads if input is null", async () => {
+			const threads = await resolver.thread();
 			expect(threads).toBeInstanceOf(Array);
 			if (threads instanceof Error) return new Error(threads.message);
 			else {
@@ -90,6 +90,22 @@ describe("Community", () => {
 				expect(testingThreadDoc.comments).toBeInstanceOf(Array);
 				expect(testingThreadDoc.usersWatching).toBeInstanceOf(Array);
 				expect(testingThreadDoc.author).toBeInstanceOf(Object);
+			}
+		});
+		it("should return all threads if input is an empty object", async () => {
+			const threads = await resolver.thread({});
+			if (threads instanceof Error) return new Error(threads.message);
+			else {
+				expect(threads).toBeInstanceOf(Array);
+				expect(threads.length).toBeGreaterThan(0);
+			}
+		});
+		it("should return all threads if input is undefined", async () => {
+			const threads = await resolver.thread(undefined);
+			if (threads instanceof Error) return new Error(threads.message);
+			else {
+				expect(threads).toBeInstanceOf(Array);
+				expect(threads.length).toBeGreaterThan(0);
 			}
 		});
 		it("should return an error when ID is not found", async () => {
@@ -140,6 +156,13 @@ describe("Community", () => {
 			const threads = await resolver.thread({
 				upvotesGTE: 100,
 				upvotes: 1000
+			});
+			expect(threads instanceof Error).toBe(true);
+		});
+		it("should return Error if both LTE and upvotes are given", async () => {
+			const threads = await resolver.thread({
+				upvotesLTE: 100,
+				upvotes: 20
 			});
 			expect(threads instanceof Error).toBe(true);
 		});


### PR DESCRIPTION
We no longer have to use the parenthesis when calling the `thread` query. The default input argument of the resolver is set to null by default.

Fixed ALMP-560