### PR TITLE
Threads need an upvote relation to users

### DIFF
--- a/gql/graphql.ts
+++ b/gql/graphql.ts
@@ -39,9 +39,6 @@ export interface IThreadByParams {
     parentLesson?: Nullable<string>;
     parentThread?: Nullable<string>;
     comments?: Nullable<string>;
-    upvotes?: Nullable<number>;
-    upvotesGTE?: Nullable<number>;
-    upvotesLTE?: Nullable<number>;
     author?: Nullable<string>;
 }
 
@@ -399,7 +396,7 @@ export interface Thread {
     author: User;
     body: string;
     comments?: Nullable<Nullable<Thread>[]>;
-    upvotes: number;
+    upvotes?: Nullable<User[]>;
     usersWatching?: Nullable<User[]>;
     parentLesson?: Nullable<Lesson>;
     createdAt: Date;

--- a/prisma/dbml/schema.dbml
+++ b/prisma/dbml/schema.dbml
@@ -23,6 +23,8 @@ Table User {
   watchedThreads Thread [not null]
   watchedThreadIDs String[] [not null]
   createdThreads Thread [not null]
+  upvotedThreads Thread [not null]
+  upvotedThreadIDs String[] [not null]
 }
 
 Table InstructorProfile {
@@ -177,12 +179,13 @@ Table Thread {
   watcherID String[] [not null]
   author User [not null]
   authorID String [not null]
-  upvotes Int [not null, default: 0]
   parentLesson Lesson
   parentLessonID String
   parentThread Thread
   parentThreadID String
   comments Thread [not null]
+  upvotes User [not null]
+  upvoteUserIDs String[] [not null]
 }
 
 Table Content {
@@ -215,6 +218,8 @@ Enum EnrollmentStatus {
 }
 
 Ref: User.watchedThreadIDs > Thread.id
+
+Ref: User.upvotedThreadIDs > Thread.id
 
 Ref: InstructorProfile.accountID - User.id
 
@@ -259,6 +264,8 @@ Ref: Thread.authorID > User.id
 Ref: Thread.parentLessonID > Lesson.id
 
 Ref: Thread.parentThreadID - Thread.id [delete: No Action]
+
+Ref: Thread.upvoteUserIDs > User.id
 
 Ref: Content.parentID > Lesson.id
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,9 @@ model User {
   watchedThreads    Thread[]           @relation(fields: [watchedThreadIDs], references: [id])
   watchedThreadIDs  String[]           @default([]) @db.ObjectId
   createdThreads    Thread[]           @relation(name: "createdThreads")
+  
+  upvotedThreads   Thread[] @relation(name: "upvote", fields: [upvotedThreadIDs], references: [id])
+  upvotedThreadIDs String[] @default([]) @db.ObjectId
 }
 
 model InstructorProfile {
@@ -93,7 +96,6 @@ model Course {
 
   moduleIDs String[] @db.ObjectId
   module    Module[] @relation(fields: [moduleIDs], references: [id])
-
 }
 
 model Module {
@@ -120,7 +122,7 @@ model Module {
   subModuleIDs    String[]     @default([]) @db.ObjectId
   collections     Collection[] @relation(name: "collections")
 
-  courseIDs String[] @db.ObjectId @default([])
+  courseIDs String[] @default([]) @db.ObjectId
   course    Course[] @relation(fields: [courseIDs], references: [id])
 }
 
@@ -147,8 +149,7 @@ model Lesson {
   collectionID String?     @db.ObjectId
   position     Int         @default(0)
 
-  content      Content[]
-
+  content Content[]
 }
 
 model ModuleFeedback {
@@ -213,32 +214,34 @@ model Thread {
   watcherID      String[] @default([]) @db.ObjectId
   author         User     @relation(name: "createdThreads", fields: [authorID], references: [id])
   authorID       String   @db.ObjectId
-  upvotes        Int      @default(0)
   parentLesson   Lesson?  @relation(fields: [parentLessonID], references: [id])
   parentLessonID String?  @db.ObjectId
 
   parentThread   Thread?  @relation("subComments", fields: [parentThreadID], references: [id], onDelete: NoAction, onUpdate: NoAction)
   parentThreadID String?  @db.ObjectId
   comments       Thread[] @relation("subComments")
+
+  upvotes       User[]   @relation(name: "upvote", fields: [upvoteUserIDs], references: [id])
+  upvoteUserIDs String[] @default([]) @db.ObjectId
 }
 
 model Content {
-  id    String @id @default(auto()) @map("_id") @db.ObjectId
-  type  String
-  link  String
-  parent Lesson @relation(fields: [parentID], references: [id])
+  id       String @id @default(auto()) @map("_id") @db.ObjectId
+  type     String
+  link     String
+  parent   Lesson @relation(fields: [parentID], references: [id])
   parentID String @db.ObjectId
 }
 
 model Progress {
-	id String @id @default(auto()) @map("_id") @db.ObjectId
-	createdAt DateTime @default(now())
-	updatedAt DateTime @default(now()) @updatedAt
-	status Float @default(0)
-	completed Boolean @default(false)
-	// Relation Fields
-	enrollment ModuleEnrollment @relation(fields: [enrollmentID], references: [id], onDelete: Cascade)
-	enrollmentID String @unique
+  id           String           @id @default(auto()) @map("_id") @db.ObjectId
+  createdAt    DateTime         @default(now())
+  updatedAt    DateTime         @default(now()) @updatedAt
+  status       Float            @default(0)
+  completed    Boolean          @default(false)
+  // Relation Fields
+  enrollment   ModuleEnrollment @relation(fields: [enrollmentID], references: [id], onDelete: Cascade)
+  enrollmentID String           @unique
 }
 
 enum UserRole {

--- a/src/community/community.resolver.ts
+++ b/src/community/community.resolver.ts
@@ -62,8 +62,8 @@ export class CommunityResolver {
 	}
 
 	@Mutation("upvoteThread")
-	async upvoteThread(@Args("id") id: string) {
-		return await this.communityService.upvoteThread(id);
+	async upvoteThread(@Args("id") id: string, @Args("userID") userID: string) {
+		return await this.communityService.upvoteThread(id, userID);
 	}
 
 	@Mutation("updateThread")

--- a/src/community/schema.graphql
+++ b/src/community/schema.graphql
@@ -25,7 +25,7 @@ type Thread {
     """
     The number of upvotes for the thread
     """
-    upvotes: Int!
+    upvotes: [User!]
     """
     The list of users who are subscribed to changes/notifications on the thread
     """
@@ -107,18 +107,6 @@ input IThreadByParams {
     The ID of a comment to be exactly equal to the given value. The query will look through all Threads that are comments and return the parent thread and the entire comments array that matches the given ID.
     """
     comments: ID
-    """
-    The number of upvotes for the thread to be exactly equal to the given value. If this parameter is given, upvotesGTE and upvotesLTE are ignored. If this parameter has a value of 0, the parameter is ignored.
-    """
-    upvotes: Int
-    """
-    The number of upvotes for the thread to be greater than or equal to the given value. If this parameter is given, upvotes is ignored. This parameter can be used in conjunction with upvotesLTE to create a range based search.
-    """
-    upvotesGTE: Int
-    """
-    The number of upvotes for the thread to be less than or equal to the given value. If this parameter is given, upvotes is ignored. This parameter can be used in conjunction with upvotesGTE to create a range based search.
-    """
-    upvotesLTE: Int
     """
     The ID of the user to be exactly equal to the given value.
     """


### PR DESCRIPTION
1. Implemented Many-to-Many relation between Threads and Users with an upvoteThreads type
2. Instead of incrementing the vote count in the upvoteThread service, we are now updating and adding the User that upvoted the Thread
3. Removed upvoteGTE and upvoteLTE