### PR TITLE
Almp 633 - Added another argument userid to the upvoteThread mutation

### DIFF
--- a/gql/graphql.ts
+++ b/gql/graphql.ts
@@ -434,7 +434,7 @@ export interface IMutation {
     login(code?: Nullable<string>): Nullable<string> | Promise<Nullable<string>>;
     createThread(data: IThreadCreateInput): Nullable<Thread> | Promise<Nullable<Thread>>;
     addCommentToThread(parentThreadID: string, data: ICommentCreateInput): Nullable<Thread> | Promise<Nullable<Thread>>;
-    upvoteThread(id: string): Nullable<Thread> | Promise<Nullable<Thread>>;
+    upvoteThread(id: string, userID: string): Nullable<Thread> | Promise<Nullable<Thread>>;
     updateThread(id: string, data: IThreadCreateInput): Nullable<Thread> | Promise<Nullable<Thread>>;
     deleteThread(id: string): Nullable<Thread> | Promise<Nullable<Thread>>;
     createDirectMessage(receiverID: string, message: string, senderID: string): boolean | Promise<boolean>;

--- a/prisma/dbml/schema.dbml
+++ b/prisma/dbml/schema.dbml
@@ -304,6 +304,7 @@ Enum ContentType {
   DOCX
   VIDEO
 }
+
 Enum FileType {
   DOCX
   DOC

--- a/src/community/community.service.ts
+++ b/src/community/community.service.ts
@@ -162,7 +162,8 @@ export class CommunityService {
 						id: userID
 					}
 				}
-			}
+			},
+			include: this.threadInclude
 		});
 	}
 

--- a/src/community/community.spec.ts
+++ b/src/community/community.spec.ts
@@ -190,9 +190,9 @@ describe("Community", () => {
 
 			const upVoteNum = await resolver.upvoteThread(threadID, accountID);
 
-			expect(
-				upVoteNum.upvotes.length === voteNum[0].upvotes.length + 1
-			).toBe(true);
+			expect(upVoteNum.upvotes.length === voteNum[0].upvotes.length + 1).toBe(
+				true
+			);
 		});
 		test("should update the thread with the given data", async () => {
 			const thread = await resolver.updateThread(threadID, {

--- a/src/community/community.spec.ts
+++ b/src/community/community.spec.ts
@@ -188,10 +188,10 @@ describe("Community", () => {
 			if (voteNum instanceof Error)
 				throw new Error("Error in upvoteThread test case");
 
-			const upVoteNum = await resolver.upvoteThread(accountID, threadID);
+			const upVoteNum = await resolver.upvoteThread(threadID, accountID);
 
 			expect(
-				upVoteNum[0].upvotes.length === voteNum[0].upvotes.length + 1
+				upVoteNum.upvotes.length === voteNum[0].upvotes.length + 1
 			).toBe(true);
 		});
 		test("should update the thread with the given data", async () => {

--- a/src/community/schema.graphql
+++ b/src/community/schema.graphql
@@ -128,7 +128,7 @@ type Mutation {
 
     addCommentToThread(parentThreadID: ID!, data: ICommentCreateInput!): Thread
 
-    upvoteThread(id: ID!): Thread
+    upvoteThread(id: ID!, userID: ID!): Thread
 
     updateThread(id: ID!, data: IThreadCreateInput!): Thread
 


### PR DESCRIPTION
1. Added another argument userid to the upvoteThread mutation
2. While testing, the query failed. Might need to fix it.