### PR TITLE
Almp 639 Created a downvote service and resolver to remove user from array

### DIFF
--- a/gql/graphql.ts
+++ b/gql/graphql.ts
@@ -440,6 +440,7 @@ export interface IMutation {
     createThread(data: IThreadCreateInput): Nullable<Thread> | Promise<Nullable<Thread>>;
     addCommentToThread(parentThreadID: string, data: ICommentCreateInput): Nullable<Thread> | Promise<Nullable<Thread>>;
     upvoteThread(id: string, userID: string): Nullable<Thread> | Promise<Nullable<Thread>>;
+    downvoteThread(id: string, userID: string): Nullable<Thread> | Promise<Nullable<Thread>>;
     updateThread(id: string, data: IThreadCreateInput): Nullable<Thread> | Promise<Nullable<Thread>>;
     deleteThread(id: string): Nullable<Thread> | Promise<Nullable<Thread>>;
     createDirectMessage(receiverID: string, message: string, senderID: string): boolean | Promise<boolean>;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,7 +1,7 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = []
-  binaryTargets   = ["native", "debian-openssl-1.1.x"]
+  binaryTargets   = ["native", "debian-openssl-1.1.x", "linux-arm64-openssl-1.1.x"]
 }
 
 datasource db {

--- a/src/community/community.resolver.ts
+++ b/src/community/community.resolver.ts
@@ -66,6 +66,11 @@ export class CommunityResolver {
 		return await this.communityService.upvoteThread(id, userID);
 	}
 
+	@Mutation("downvoteThread")
+	async downvoteThread(@Args("id") id: string, @Args("userID") userID: string) {
+		return await this.communityService.downvoteThread(id, userID);
+	}
+
 	@Mutation("updateThread")
 	async updateThread(
 		@Args("id") id: string,

--- a/src/community/community.service.ts
+++ b/src/community/community.service.ts
@@ -169,14 +169,14 @@ export class CommunityService {
 				id
 			},
 			include: {
-				upvotes: true,
+				upvotes: true
 			}
 		});
 
 		if (!thread) {
-			throw new Error('Thread not found');
+			throw new Error("Thread not found");
 		}
-		
+
 		return this.prisma.thread.update({
 			where: {
 				id
@@ -202,15 +202,15 @@ export class CommunityService {
 		});
 
 		if (!thread) {
-			throw new Error('Thread not found');
+			throw new Error("Thread not found");
 		}
 
 		// Check if the userID is in the upvotes array
-		const userUpvoted = thread.upvotes.some(upvote => upvote.id === userID);
+		const userUpvoted = thread.upvotes.some((upvote) => upvote.id === userID);
 
 		// If the userID is not in the upvotes array, return an error
 		if (!userUpvoted) {
-			throw new Error('User has not upvoted this thread');
+			throw new Error("User has not upvoted this thread");
 		}
 
 		// Update the thread, removing the userID from the upvotes array
@@ -223,7 +223,7 @@ export class CommunityService {
 					disconnect: {
 						id: userID
 					}
-				},
+				}
 			},
 			include: this.threadInclude
 		});

--- a/src/community/community.spec.ts
+++ b/src/community/community.spec.ts
@@ -225,7 +225,7 @@ describe("Community", () => {
                 throw new Error("Error in upvoteThread test case");
 
             const upVoteNum = await resolver.upvoteThread(threadID, accountID);
-			// stuck at upvoted status, upvote a second time won't increment one more time
+			// stuck at upvoted status, attempting to upvote a upvoted thread (self) for a second time will not increment the count
             expect(upVoteNum.upvotes.length === voteNum[0].upvotes.length + 1).toBe(
                 false
             );

--- a/src/community/community.spec.ts
+++ b/src/community/community.spec.ts
@@ -223,11 +223,11 @@ describe("Community", () => {
 			const voteNum = await resolver.thread({ id: threadID });
 			if (voteNum instanceof Error)
 				throw new Error("Error in upvoteThread test case");
-            const upVoteNum = await resolver.upvoteThread(threadID, accountID);
+			const upVoteNum = await resolver.upvoteThread(threadID, accountID);
 			// stuck at upvoted status, attempting to upvote a upvoted thread (self) for a second time will not increment the count
-            expect(upVoteNum.upvotes.length === voteNum[0].upvotes.length + 1).toBe(
-                false
-            );
+			expect(upVoteNum.upvotes.length === voteNum[0].upvotes.length + 1).toBe(
+				false
+			);
 			// expect accountID inside of the upvotes Users array
 			expect(upVoteNum.upvotes.some((upvote) => upvote.id === accountID)).toBe(
 				true

--- a/src/community/community.spec.ts
+++ b/src/community/community.spec.ts
@@ -219,6 +219,27 @@ describe("Community", () => {
 				true
 			);
 		});
+		test("should decrease vote count by 1", async () => {
+            const voteNum = await resolver.thread({ id: threadID });
+            if (voteNum instanceof Error)
+                throw new Error("Error in upvoteThread test case");
+
+            const upVoteNum = await resolver.upvoteThread(threadID, accountID);
+			// stuck at upvoted status, upvote a second time won't increment one more time
+            expect(upVoteNum.upvotes.length === voteNum[0].upvotes.length + 1).toBe(
+                false
+            );
+			// expect accountID inside of the upvotes Users array
+            expect(upVoteNum.upvotes.some(upvote => upvote.id === accountID)).toBe(true);
+			// resolver on downvoteThread function
+			const downVoteNum = await resolver.downvoteThread(threadID, accountID);
+			// after downvote mutation, size of upvotes array should decrement by 1
+			expect(downVoteNum.upvotes.length === voteNum[0].upvotes.length - 1).toBe(
+                true
+            );
+			// accountID should no longer be found in the updated Array (after downvote)
+            expect(downVoteNum.upvotes.some(upvote => upvote.id === accountID)).toBe(false);
+		});
 		test("should update the thread with the given data", async () => {
 			const thread = await resolver.updateThread(threadID, {
 				title: "This is an updated thread",

--- a/src/community/schema.graphql
+++ b/src/community/schema.graphql
@@ -130,6 +130,8 @@ type Mutation {
 
     upvoteThread(id: ID!, userID: ID!): Thread
 
+    downvoteThread(id: ID!, userID: ID!): Thread
+
     updateThread(id: ID!, data: IThreadCreateInput!): Thread
 
     deleteThread(id: ID!): Thread


### PR DESCRIPTION
1. 1 failing test out of 19 (18 passed, 1 failed)
Invalid `this.prisma.user.delete()` invocation in
/Users/cashin/Documents/github/639-almp/src/user/user.service.ts:295:34

  292 if (res === null) {
  293   return new Error(`The user with ${id}, does not exist`);
  294 } else {
→ 295   return this.prisma.user.delete(
  The change you are trying to make would violate the required relation 'createdThreads' between the `Thread` and `User` models.
2. working test cases for downvote and upvotes.