### PR TITLE
feat(app): Added query to get the API Version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "emseapi",
-	"version": "0.2.4",
+	"version": "0.3.5",
 	"private": true,
 	"scripts": {
 		"start": "nest start",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,7 +13,8 @@ import { CommunityModule } from "./community/community.module";
 import { DirectMessageModule } from "@/direct-message/direct-message.module";
 import { ProgressModule } from "@/progress";
 import { ApolloServerPluginLandingPageLocalDefault } from "apollo-server-core";
-import {QuizModule} from "@/quiz/quiz.module";
+import { QuizModule } from "@/quiz/quiz.module";
+import { AppResolver } from "@/app.resolver";
 
 @Scalar("Date")
 export class DateScalar implements CustomScalar<string, Moment> {
@@ -68,7 +69,7 @@ const playgroundConfig =
 				"graphql-ws": true,
 				"subscriptions-transport-ws": false
 			},
-			context: ({req, res}) => ({req, res})
+			context: ({ req, res }) => ({ req, res })
 		}),
 		UserModule,
 		PoSModule,
@@ -80,6 +81,6 @@ const playgroundConfig =
 		QuizModule
 	],
 	controllers: [],
-	providers: [DateScalar]
+	providers: [DateScalar, AppResolver]
 })
 export class AppModule {}

--- a/src/app.resolver.ts
+++ b/src/app.resolver.ts
@@ -1,0 +1,18 @@
+import { Resolver, Query } from "@nestjs/graphql";
+import * as dotenv from "dotenv";
+
+@Resolver("App")
+export class AppResolver {
+	constructor() {
+		dotenv.config();
+	}
+	@Query("appVersion")
+	async appVersion() {
+		return process.env.npm_package_version;
+	}
+
+	@Query("appInstance")
+	async appInstance() {
+		return process.env.NODE_ENV;
+	}
+}

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -1,0 +1,4 @@
+type Query {
+    appVersion: String!
+    appInstance: String!
+}


### PR DESCRIPTION
1. API version number is now accessible via the `appVersion` query
2. Currently running Node environment is accessible via the `appInstace` query (assumes node env is set by the system)