### PR TITLE
Add Learning objectives to modules (lessons)

### DIFF
--- a/gql/graphql.ts
+++ b/gql/graphql.ts
@@ -245,6 +245,7 @@ export interface LessonInput {
     content?: Nullable<string>;
     collection: string;
     position?: Nullable<number>;
+    objectives?: Nullable<string[]>;
 }
 
 export interface LessonFields {
@@ -254,6 +255,7 @@ export interface LessonFields {
     thread?: Nullable<string>;
     collection?: Nullable<string>;
     position?: Nullable<number>;
+    objectives?: Nullable<string[]>;
 }
 
 export interface ProgressArgs {
@@ -702,6 +704,7 @@ export interface Lesson {
     position?: Nullable<number>;
     quizzes?: Nullable<Quiz[]>;
     lessonProgress?: Nullable<Nullable<LessonProgress>[]>;
+    objectives: string[];
 }
 
 export interface Content {

--- a/gql/graphql.ts
+++ b/gql/graphql.ts
@@ -490,7 +490,7 @@ export interface IMutation {
     createCollection(data: CreateCollectionArgs): Collection | Promise<Collection>;
     updateCollection(id: string, data: CollectionFields): Collection | Promise<Collection>;
     createLesson(input: LessonInput): Lesson | Promise<Lesson>;
-    updateLesson(input?: Nullable<LessonFields>): Nullable<Lesson> | Promise<Nullable<Lesson>>;
+    updateLesson(input?: Nullable<LessonFields>, replaceObj?: Nullable<boolean>): Nullable<Lesson> | Promise<Nullable<Lesson>>;
     deleteLesson(id: string): Nullable<Lesson> | Promise<Nullable<Lesson>>;
     createContent(input: CreateContentArgs): Content | Promise<Content>;
     updateContent(input: ContentFields): Nullable<Content[]> | Promise<Nullable<Content[]>>;

--- a/prisma/dbml/schema.dbml
+++ b/prisma/dbml/schema.dbml
@@ -128,6 +128,7 @@ Table Lesson {
   collection Collection [not null]
   collectionID String [not null]
   position Int [not null, default: 0]
+  objectives String[] [not null]
   content Content [not null]
   quizzes Quiz [not null]
   lessonProgress LessonProgress [not null]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -152,6 +152,7 @@ model Lesson {
   collection   Collection @relation(fields: [collectionID], references: [id], onDelete: Cascade)
   collectionID String     @db.ObjectId
   position     Int        @default(0)
+  objectives   String[]   @default([])
 
   content        Content[]
   quizzes        Quiz[]

--- a/src/program/program.resolver.ts
+++ b/src/program/program.resolver.ts
@@ -296,7 +296,10 @@ export class ProgramResolver {
 	}
 
 	@Mutation("updateLesson")
-	async updateLesson(@Args("input") input: LessonFields, @Args("replaceObj") replaceObj: boolean = false) {
+	async updateLesson(
+		@Args("input") input: LessonFields,
+		@Args("replaceObj") replaceObj: boolean = false
+	) {
 		return await this.programService.updateLesson(input, replaceObj);
 	}
 

--- a/src/program/program.resolver.ts
+++ b/src/program/program.resolver.ts
@@ -296,8 +296,8 @@ export class ProgramResolver {
 	}
 
 	@Mutation("updateLesson")
-	async updateLesson(@Args("input") input: LessonFields) {
-		return await this.programService.updateLesson(input);
+	async updateLesson(@Args("input") input: LessonFields, @Args("replaceObj") replaceObj: boolean = false) {
+		return await this.programService.updateLesson(input, replaceObj);
 	}
 
 	@Mutation("deleteLesson")

--- a/src/program/program.service.ts
+++ b/src/program/program.service.ts
@@ -1039,23 +1039,21 @@ export class ProgramService {
 				where: {
 					id
 				}
-			})
+			});
 			if (current) {
 				// Check if the value is already in the list if its not add it
 				current.objectives.map((value) => {
 					if (!newObjectives.includes(value)) {
 						newObjectives.push(value);
 					}
-				})
+				});
 			}
 		}
-
-
 
 		const payload = {
 			...(id && { id }),
 			...(name && { name }),
-			...(collection && { collection }),
+			...(collection && { collection })
 		};
 
 		const args = Prisma.validator<Prisma.LessonUpdateArgs>()({

--- a/src/program/program.service.ts
+++ b/src/program/program.service.ts
@@ -1032,7 +1032,6 @@ export class ProgramService {
 			collection,
 			objectives,
 			hours
-
 		} = input;
 
 		const newObjectives = objectives;

--- a/src/program/program.service.ts
+++ b/src/program/program.service.ts
@@ -1006,7 +1006,8 @@ export class ProgramService {
 						id: input.collection ? input.collection : undefined
 					}
 				},
-				position: input.position ? input.position : undefined
+				position: input.position ? input.position : undefined,
+				objectives: input.objectives ? input.objectives : undefined
 			},
 			include: this.lessonInclude
 		});

--- a/src/program/program.service.ts
+++ b/src/program/program.service.ts
@@ -1007,7 +1007,7 @@ export class ProgramService {
 					}
 				},
 				position: input.position ? input.position : undefined,
-				objectives: input.objectives ? input.objectives : undefined
+				objectives: input.objectives ? input.objectives : undefined,
 				hours: input.hours
 			},
 			include: this.lessonInclude
@@ -1030,7 +1030,7 @@ export class ProgramService {
 			// Being refererenced would all have to be modified in this update Lesson.
 			// thread,
 			collection,
-			objectives
+			objectives,
 			hours
 
 		} = input;
@@ -1068,7 +1068,7 @@ export class ProgramService {
 				name: payload.name,
 				collectionID: payload.collection,
 				position: input.position ? input.position : undefined,
-				objectives: newObjectives ? newObjectives : undefined
+				objectives: newObjectives ? newObjectives : undefined,
 				hours: payload.hours
 			}
 		});

--- a/src/program/program.service.ts
+++ b/src/program/program.service.ts
@@ -503,14 +503,15 @@ export class ProgramService {
 
 	//Fetch Lessons
 	async lesson(input: LessonFields) {
-		const { id, name, content, collection, position } = input;
+		const { id, name, content, collection, position, objectives} = input;
 
 		const where = Prisma.validator<Prisma.LessonWhereInput>()({
 			...(id && { id }),
 			...(name && { name }),
 			...(position && { position }),
 			collection: { id: collection ? collection : undefined },
-			content: content ? { some: { id: content } } : undefined
+			content: content ? { some: { id: content } } : undefined,
+			objectives: objectives ? { hasEvery: objectives} : undefined
 		});
 
 		return this.prisma.lesson.findMany({

--- a/src/program/program.service.ts
+++ b/src/program/program.service.ts
@@ -503,7 +503,7 @@ export class ProgramService {
 
 	//Fetch Lessons
 	async lesson(input: LessonFields) {
-		const { id, name, content, collection, position, objectives} = input;
+		const { id, name, content, collection, position, objectives } = input;
 
 		const where = Prisma.validator<Prisma.LessonWhereInput>()({
 			...(id && { id }),
@@ -511,7 +511,7 @@ export class ProgramService {
 			...(position && { position }),
 			collection: { id: collection ? collection : undefined },
 			content: content ? { some: { id: content } } : undefined,
-			objectives: objectives ? { hasEvery: objectives} : undefined
+			objectives: objectives ? { hasEvery: objectives } : undefined
 		});
 
 		return this.prisma.lesson.findMany({

--- a/src/program/schema.graphql
+++ b/src/program/schema.graphql
@@ -988,8 +988,12 @@ type Mutation {
 	createLesson(input: LessonInput!): Lesson!
 	"""
 	Update a lesson given its ID
+	The input parameter is the data that will be updated in the Lesson as well as the ID of the lesson to be updated.
+	The replaceObj parameter specifies the mode in which lesson objectives should be updated. A true value will repalce
+	existing objectives with the new list passed in, whereas a false value (default) will add the strings in the list to
+	the existing data.
 	"""
-	updateLesson(input: LessonFields): Lesson
+	updateLesson(input: LessonFields, replaceObj: Boolean): Lesson
 
 	deleteLesson(id: String!): Lesson
 

--- a/src/program/schema.graphql
+++ b/src/program/schema.graphql
@@ -382,6 +382,10 @@ type Lesson {
 	The progress model that is associated with this lesson
 	"""
 	lessonProgress: [LessonProgress]
+	"""
+	A list of learning objectives being covered in this module
+	"""
+	objectives: 	[String!]!
 }
 
 type Content {
@@ -826,6 +830,10 @@ input LessonInput {
 	The index of the lesson in the collection
 	"""
 	position: Int
+	"""
+	The list of learning objectives for this module
+	"""
+	objectives: [String!]
 }
 
 input LessonFields {
@@ -853,6 +861,10 @@ input LessonFields {
 	The index of the lesson in the collection
 	"""
 	position: Int
+	"""
+	Learning objectives that are taught in this module
+	"""
+	objectives: [String!]
 }
 
 type Mutation {


### PR DESCRIPTION
- Added objectives to lesson model in schema
- Added second optional parameter to update lesson mutation that decides if objectives will be replaced or appended (defaults to append)
- Added objectives to mutations for lessons

**Note**
The ability to query by objectives has not been implemented yet, objectives can be retrieved from the DB but filtering by objectives is not added yet. I figured that should be its own ticket, if it should be included send this back and I will add it.