### PR TITLE
feat(instructor): Deprecated unused fields in instructor profile model

### DIFF
--- a/gql/graphql.ts
+++ b/gql/graphql.ts
@@ -436,12 +436,9 @@ export interface InstructorProfileInput {
     officeLocation?: Nullable<string>;
     officeHours?: Nullable<string>;
     contactPolicy?: Nullable<string>;
-    phone?: Nullable<string>;
     background?: Nullable<string>;
     researchInterest?: Nullable<string>;
     selectedPapersAndPublications?: Nullable<Nullable<string>[]>;
-    personalWebsite?: Nullable<string>;
-    philosophy?: Nullable<string>;
 }
 
 export interface SocialInput {
@@ -810,12 +807,9 @@ export interface InstructorProfile {
     officeLocation?: Nullable<string>;
     officeHours?: Nullable<string>;
     contactPolicy?: Nullable<string>;
-    phone?: Nullable<string>;
     background?: Nullable<string>;
     researchInterest?: Nullable<string>;
     selectedPapersAndPublications?: Nullable<Nullable<string>[]>;
-    personalWebsite?: Nullable<string>;
-    philosophy?: Nullable<string>;
 }
 
 export interface User {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,12 +54,9 @@ model InstructorProfile {
   officeLocation                String?
   officeHours                   String?
   contactPolicy                 String?
-  phone                         String?
   background                    String?
   researchInterest              String?
   selectedPapersAndPublications String[] @default([])
-  personalWebsite               String?
-  philosophy                    String?
 }
 
 model PlanOfStudy {

--- a/src/user/schema.graphql
+++ b/src/user/schema.graphql
@@ -55,10 +55,6 @@ type InstructorProfile {
 	"""
 	contactPolicy: String
 	"""
-	Contact phone of th user
-	"""
-	phone: String
-	"""
 	Background of the Profile
 	"""
 	background: String
@@ -70,14 +66,6 @@ type InstructorProfile {
 	The papers and publications selected
 	"""
 	selectedPapersAndPublications: [String]
-	"""
-	Personal website of the user
-	"""
-	personalWebsite: String
-	"""
-	The preferred teaching philosophy of the instructor
-	"""
-	philosophy: String
 }
 
 type User {
@@ -328,10 +316,6 @@ input InstructorProfileInput {
 	"""
 	contactPolicy: String
 	"""
-	Phone of Instructor Profile
-	"""
-	phone: String
-	"""
 	Background of Profile
 	"""
 	background: String
@@ -343,14 +327,6 @@ input InstructorProfileInput {
 	Selected Papers and Publications of the Instructor
 	"""
 	selectedPapersAndPublications: [String]
-	"""
-	Personal Website of the Instructor
-	"""
-	personalWebsite: String
-	"""
-	Philosophy of the Instructor
-	"""
-	philosophy: String
 }
 
 input SocialInput {

--- a/src/user/user.spec.ts
+++ b/src/user/user.spec.ts
@@ -41,10 +41,10 @@ describe("Account services", () => {
 	const updatedInstructorProfileReset: InstructorProfileInput = {
 		title: "Department Chair",
 		officeLocation: "Online",
-		officeHours: "Anytime",
+		officeHours: ["Anytime"],
 		contactPolicy: "Email",
 		background: "I am a professor",
-		researchInterest: "I am a professor",
+		researchInterest: ["I am a professor"],
 		selectedPapersAndPublications: [""]
 	};
 
@@ -154,11 +154,11 @@ describe("Account services", () => {
 			const updatedInstructorProfile: InstructorProfileInput = {
 				title: "Adjunct Professor",
 				officeLocation: "ESB 2101",
-				officeHours: "9AM - 5PM - MWF",
+				officeHours: ["9AM - 5PM - MWF"],
 				contactPolicy: "Email",
 				background:
 					"I'm a very experienced professor, and I only use books from 50 years ago.",
-				researchInterest: "Technology",
+				researchInterest: ["Technology"],
 				selectedPapersAndPublications: [""]
 			};
 			const input: UpdateUser = {

--- a/src/user/user.spec.ts
+++ b/src/user/user.spec.ts
@@ -2,14 +2,14 @@ import { UserService } from "./user.service";
 import { UserResolver } from "./user.resolver";
 import { PrismaService } from "@/prisma.service";
 import {
-	Social,
-	UpdateUser,
-	User,
 	InstructorProfileInput,
-	SocialInput
+	Social,
+	SocialInput,
+	UpdateUser,
+	User
 } from "@/types/graphql";
 import { shuffle } from "../../utils/tests";
-import { test, describe, afterAll, expect } from "vitest";
+import { afterAll, describe, expect, test } from "vitest";
 
 describe("Account services", () => {
 	let service: UserService;
@@ -43,12 +43,9 @@ describe("Account services", () => {
 		officeLocation: "Online",
 		officeHours: "Anytime",
 		contactPolicy: "Email",
-		phone: "757-555-5555",
 		background: "I am a professor",
 		researchInterest: "I am a professor",
-		selectedPapersAndPublications: [""],
-		personalWebsite: "https://odu.edu/emse",
-		philosophy: "I  teach people"
+		selectedPapersAndPublications: [""]
 	};
 
 	prisma = new PrismaService();
@@ -152,7 +149,6 @@ describe("Account services", () => {
 			expect(instructorProfile.researchInterest).toBeDefined();
 			expect(instructorProfile.selectedPapersAndPublications).toBeDefined();
 			expect(instructorProfile.personalWebsite).toBeDefined();
-			expect(instructorProfile.philosophy).toBeDefined();
 		});
 		test("should update instructor profile given input argument", async () => {
 			const updatedInstructorProfile: InstructorProfileInput = {
@@ -160,13 +156,10 @@ describe("Account services", () => {
 				officeLocation: "ESB 2101",
 				officeHours: "9AM - 5PM - MWF",
 				contactPolicy: "Email",
-				phone: "111-222-3333",
 				background:
 					"I'm a very experienced professor, and I only use books from 50 years ago.",
 				researchInterest: "Technology",
-				selectedPapersAndPublications: [""],
-				personalWebsite: "https://odu.edu/emse",
-				philosophy: "I  teach people"
+				selectedPapersAndPublications: [""]
 			};
 			const input: UpdateUser = {
 				id: userDocumentID,
@@ -191,9 +184,6 @@ describe("Account services", () => {
 			expect(updateUser.instructorProfile.contactPolicy).toEqual(
 				updatedInstructorProfile.contactPolicy
 			);
-			expect(updateUser.instructorProfile.phone).toEqual(
-				updatedInstructorProfile.phone
-			);
 			expect(updateUser.instructorProfile.background).toEqual(
 				updatedInstructorProfile.background
 			);
@@ -203,12 +193,6 @@ describe("Account services", () => {
 			expect(
 				updateUser.instructorProfile.selectedPapersAndPublications
 			).toEqual(updatedInstructorProfile.selectedPapersAndPublications);
-			expect(updateUser.instructorProfile.personalWebsite).toEqual(
-				updatedInstructorProfile.personalWebsite
-			);
-			expect(updateUser.instructorProfile.philosophy).toEqual(
-				updatedInstructorProfile.philosophy
-			);
 		});
 	});
 	describe("Social", () => {


### PR DESCRIPTION
1. Removed fields from the DB model that either aren't needed or are covered by a different model
2. Removed fields from the API schema
3. Updated test cases to match schema

**Removed fields:**
- personalWebsite (covered by the Social model)
- philosophy (isn't needed)
- phone (covered by the User model)